### PR TITLE
Added Sudoku spec based on Galois, Inc. blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ capabilities of [Cryptol](https://github.com/GaloisInc/cryptol) and the [Softwar
       - [XOR](https://github.com/GaloisInc/cryptol/blob/master/examples/xor_cipher.cry): show that double xor is the identity
       - [Caesar Ciphers](specs/Primitive/Symmetric/Cipher/Stream/Caesar.cry): show that encrypt/decrypt is the identity
    - Show examples of how the SAT tool can be used to solve puzzles
-      - [Sudoku](https://galois.com/blog/2009/03/solving-sudoku-using-cryptol)
+      - [Sudoku](specs/Misc/Sudoku.cry): show that solutions to Sudoku puzzles exist and are unique
       - [n-Queens](https://github.com/GaloisInc/cryptol/blob/master/examples/funstuff/NQueens.cry)
 6. Programming with Cryptol, Round 1
    - Present material on some of the Cryptol language basics, students have seen

--- a/specs/Misc/Sudoku.cry
+++ b/specs/Misc/Sudoku.cry
@@ -4,191 +4,202 @@
  * ) and updated to Cryptol 2.8.1
  */
 module Misc::Sudoku where
-  /** number in [1..9] */
-  type Num = [width 9]
 
-  /** row, column, or 3x3 square of `Num` */
-  type Group = [9]Num
+/** number in [1..9] */
+type Num = [width 9]
 
-  /** 9x9 grid of `Num` (Sudoku) */
-  type Board = [9]Group
+/** row, column, or 3x3 square of `Num` */
+type Group = [9]Num
+
+/** 9x9 grid of `Num` (Sudoku) */
+type Board = [9]Group
 
 
-  /** whether a full `Board` is valid */
-  valid:
-    Board -> Bit
-  valid rows =
-    all _check (rows # columns # squares)
-      where
-        columns = transpose rows
-        regions = transpose [ groupBy`{3} row
-                            | row <- rows ]
-        squares = [ join sq 
-                  | sq <- groupBy`{3} (join regions) ]
+/** whether `Group` `G` contains one of each number 1-9 */
+check:
+  Group -> Bit
+check G =
+  permutes G [1..9]
+
+/** whether a full `Board` is valid */
+valid:
+  Board -> Bit
+valid rows =
+  all check (rows # columns # squares)
+    where
+      columns = transpose rows
+      regions = transpose [ groupBy`{3} row
+                          | row <- rows ]
+      squares = [ join sq 
+                | sq <- groupBy`{3} (join regions) ]
+
+/**
+  * The easy puzzle in [Solving Sudoku Using Cryptol](
+  * https://galois.com/blog/2009/03/solving-sudoku-using-cryptol)
+  * has a solution.
+  */
+easy_puzzle:
+  [_]Num -> Bit
+easy_puzzle
+     [a1,     a3,     a5, a6,         a9,
+      b1,         b4, b5,     b7,     b9,
+      c2,     c4, c5, c6, c7, c8, c9    ,
+      d1, d2,     d4,     d6, d7, d8    ,
+      e1, e2, e3,     e5,     e7, e8, e9,
+      f2, f3, f4,     f6,     f8, f9    ,
+      g1, g2, g3, g4, g5, g6,     g8    ,
+      h1,     h3,     h5, h6,         h9,
+      i1,         i4, i5,     i7,     i9] =
+  valid
+    [[a1,  9, a3,  7, a5, a6,  8,  6, a9],
+     [b1,  3,  1, b4, b5,  5, b7,  2, b9],
+     [ 8, c2,  6, c4, c5, c6, c7, c8, c9],
+     [d1, d2,  7, d4,  5, d6, d7, d8,  6],
+     [e1, e2, e3,  3, e5,  7, e7, e8, e9],
+     [ 5, f2, f3, f4,  1, f6,  7, f8, f9],
+     [g1, g2, g3, g4, g5, g6,  1, g8,  9],
+     [h1,  2, h3,  6, h5, h6,  3,  5, h9],
+     [i1,  5,  4, i4, i5,  8, i7,  7, i9]]
+
+/** a solution to the easy puzzle */
+easy_solution:
+  Board
+easy_solution =
+  [[2, 9, 5, 7, 4, 3, 8, 6, 1],
+   [4, 3, 1, 8, 6, 5, 9, 2, 7],
+   [8, 7, 6, 1, 9, 2, 5, 4, 3],
+   [3, 8, 7, 4, 5, 9, 2, 1, 6],
+   [6, 1, 2, 3, 8, 7, 4, 9, 5],
+   [5, 4, 9, 2, 1, 6, 7, 3, 8],
+   [7, 6, 3, 5, 2, 4, 1, 8, 9],
+   [9, 2, 8, 6, 7, 1, 3, 5, 4],
+   [1, 5, 4, 9, 3, 8, 6, 7, 2]]
+
+/** The easy puzzle's solution is valid. */
+easy_solution_valid:
+  Bit
+property easy_solution_valid =
+  valid easy_solution
+
+/** The easy puzzle's solution is unique. */
+easy_unique:
+  [_]Num -> Bit
+property easy_unique
+         [a1,     a3,     a5, a6,         a9,
+          b1,         b4, b5,     b7,     b9,
+          c2,     c4, c5, c6, c7, c8, c9    ,
+          d1, d2,     d4,     d6, d7, d8    ,
+          e1, e2, e3,     e5,     e7, e8, e9,
+          f2, f3, f4,     f6,     f8, f9    ,
+          g1, g2, g3, g4, g5, g6,     g8    ,
+          h1,     h3,     h5, h6,         h9,
+          i1,         i4, i5,     i7,     i9] =
+  solution == easy_solution \/ ~ valid solution
+    where
+      solution = 
+        [[a1,  9, a3,  7, a5, a6,  8,  6, a9],
+         [b1,  3,  1, b4, b5,  5, b7,  2, b9],
+         [ 8, c2,  6, c4, c5, c6, c7, c8, c9],
+         [d1, d2,  7, d4,  5, d6, d7, d8,  6],
+         [e1, e2, e3,  3, e5,  7, e7, e8, e9],
+         [ 5, f2, f3, f4,  1, f6,  7, f8, f9],
+         [g1, g2, g3, g4, g5, g6,  1, g8,  9],
+         [h1,  2, h3,  6, h5, h6,  3,  5, h9],
+         [i1,  5,  4, i4, i5,  8, i7,  7, i9]]
+
+
+/**
+  * Arto Inkala's ["World's Hardest Sudoku"](
+  * https://www.conceptispuzzles.com/index.aspx?uri=info/article/424)
+  * has a solution.
+  */
+hard_puzzle:
+  [_]Num -> Bit
+hard_puzzle
+     [    a2, a3, a4, a5, a6, a7, a8, a9,
+      b1, b2,         b5, b6, b7, b8, b9,
+      c1,     c3, c4,     c6,     c8, c9,
+      d1,     d3, d4, d5,     d7, d8, d9,
+      e1, e2, e3, e4,             e8, e9,
+      f1, f2, f3,     f5, f6, f7,     f9,
+      g1, g2,     g4, g5, g6, g7,        
+      h1, h2,         h5, h6, h7,     h9,
+      i1,     i3, i4, i5, i6,     i8, i9] =
+  valid
+    [[ 8, a2, a3, a4, a5, a6, a7, a8, a9],
+     [b1, b2,  3,  6, b5, b6, b7, b8, b9],
+     [c1,  7, c3, c4,  9, c6,  2, c8, c9],
+     [d1,  5, d3, d4, d5,  7, d7, d8, d9],
+     [e1, e2, e3, e4,  4,  5,  7, e8, e9],
+     [f1, f2, f3,  1, f5, f6, f7,  3, f9],
+     [g1, g2,  1, g4, g5, g6, g7,  6,  8],
+     [h1, h2,  8,  5, h5, h6, h7,  1, h9],
+     [i1,  9, i3, i4, i5, i6,  4, i8, i9]]
+
+/** a solution to the "World's Hardest Sudoku" */
+hard_solution:
+  Board
+hard_solution =
+  [[8, 1, 2, 7, 5, 3, 6, 4, 9],
+   [9, 4, 3, 6, 8, 2, 1, 7, 5],
+   [6, 7, 5, 4, 9, 1, 2, 8, 3],
+   [1, 5, 4, 2, 3, 7, 8, 9, 6],
+   [3, 6, 9, 8, 4, 5, 7, 2, 1],
+   [2, 8, 7, 1, 6, 9, 5, 3, 4],
+   [5, 2, 1, 9, 7, 4, 3, 6, 8],
+   [4, 3, 8, 5, 2, 6, 9, 1, 7],
+   [7, 9, 6, 3, 1, 8, 4, 5, 2]]
+
+/** The hard puzzle's solution is valid. */
+hard_solution_valid:
+  Bit
+property hard_solution_valid =
+  valid hard_solution
+
+/** The "World's Hardest Sudoku" has a unique solution. */
+hard_unique:
+  [_]Num -> Bit
+property hard_unique
+         [    a2, a3, a4, a5, a6, a7, a8, a9,
+          b1, b2,         b5, b6, b7, b8, b9,
+          c1,     c3, c4,     c6,     c8, c9,
+          d1,     d3, d4, d5,     d7, d8, d9,
+          e1, e2, e3, e4,             e8, e9,
+          f1, f2, f3,     f5, f6, f7,     f9,
+          g1, g2,     g4, g5, g6, g7,        
+          h1, h2,         h5, h6, h7,     h9,
+          i1,     i3, i4, i5, i6,     i8, i9] =
+  solution == hard_solution \/ ~ valid solution
+    where
+      solution =
+        [[ 8, a2, a3, a4, a5, a6, a7, a8, a9],
+         [b1, b2,  3,  6, b5, b6, b7, b8, b9],
+         [c1,  7, c3, c4,  9, c6,  2, c8, c9],
+         [d1,  5, d3, d4, d5,  7, d7, d8, d9],
+         [e1, e2, e3, e4,  4,  5,  7, e8, e9],
+         [f1, f2, f3,  1, f5, f6, f7,  3, f9],
+         [g1, g2,  1, g4, g5, g6, g7,  6,  8],
+         [h1, h2,  8,  5, h5, h6, h7,  1, h9],
+         [i1,  9, i3, i4, i5, i6,  4, i8, i9]]
+
+
+private
+
+  /** whether finite sequence `G` contains element `x` */
+  contains:
+    {a, n}
+    (Cmp a, fin n) =>
+    [n]a -> a -> Bit
+  contains G x =
+    any ((==) x) G
 
   /**
-   * The easy puzzle in [Solving Sudoku Using Cryptol](
-   * https://galois.com/blog/2009/03/solving-sudoku-using-cryptol)
-   * has a solution.
-   */
-  easy_puzzle:
-    [_]Num -> Bit
-  easy_puzzle
-      [a1,     a3,     a5, a6,         a9,
-       b1,         b4, b5,     b7,     b9,
-       c2,     c4, c5, c6, c7, c8, c9    ,
-       d1, d2,     d4,     d6, d7, d8    ,
-       e1, e2, e3,     e5,     e7, e8, e9,
-       f2, f3, f4,     f6,     f8, f9    ,
-       g1, g2, g3, g4, g5, g6,     g8    ,
-       h1,     h3,     h5, h6,         h9,
-       i1,         i4, i5,     i7,     i9] =
-    valid solution
-      where
-        solution = 
-          [[a1,  9, a3,  7, a5, a6,  8,  6, a9],
-           [b1,  3,  1, b4, b5,  5, b7,  2, b9],
-           [ 8, c2,  6, c4, c5, c6, c7, c8, c9],
-           [d1, d2,  7, d4,  5, d6, d7, d8,  6],
-           [e1, e2, e3,  3, e5,  7, e7, e8, e9],
-           [ 5, f2, f3, f4,  1, f6,  7, f8, f9],
-           [g1, g2, g3, g4, g5, g6,  1, g8,  9],
-           [h1,  2, h3,  6, h5, h6,  3,  5, h9],
-           [i1,  5,  4, i4, i5,  8, i7,  7, i9]]
-
-  /** a solution to the easy puzzle */
-  easy_solution:
-    Board
-  easy_solution =
-    [[2, 9, 5, 7, 4, 3, 8, 6, 1],
-     [4, 3, 1, 8, 6, 5, 9, 2, 7],
-     [8, 7, 6, 1, 9, 2, 5, 4, 3],
-     [3, 8, 7, 4, 5, 9, 2, 1, 6],
-     [6, 1, 2, 3, 8, 7, 4, 9, 5],
-     [5, 4, 9, 2, 1, 6, 7, 3, 8],
-     [7, 6, 3, 5, 2, 4, 1, 8, 9],
-     [9, 2, 8, 6, 7, 1, 3, 5, 4],
-     [1, 5, 4, 9, 3, 8, 6, 7, 2]]
-
-  /** The easy puzzle has a unique solution. */
-  easy_unique:
-    [_]Num -> Bit
-  property easy_unique
-      [a1,     a3,     a5, a6,         a9,
-       b1,         b4, b5,     b7,     b9,
-       c2,     c4, c5, c6, c7, c8, c9    ,
-       d1, d2,     d4,     d6, d7, d8    ,
-       e1, e2, e3,     e5,     e7, e8, e9,
-       f2, f3, f4,     f6,     f8, f9    ,
-       g1, g2, g3, g4, g5, g6,     g8    ,
-       h1,     h3,     h5, h6,         h9,
-       i1,         i4, i5,     i7,     i9] =
-    valid easy_solution /\ (solution == easy_solution \/ ~ valid solution)
-      where
-        solution = 
-          [[a1,  9, a3,  7, a5, a6,  8,  6, a9],
-           [b1,  3,  1, b4, b5,  5, b7,  2, b9],
-           [ 8, c2,  6, c4, c5, c6, c7, c8, c9],
-           [d1, d2,  7, d4,  5, d6, d7, d8,  6],
-           [e1, e2, e3,  3, e5,  7, e7, e8, e9],
-           [ 5, f2, f3, f4,  1, f6,  7, f8, f9],
-           [g1, g2, g3, g4, g5, g6,  1, g8,  9],
-           [h1,  2, h3,  6, h5, h6,  3,  5, h9],
-           [i1,  5,  4, i4, i5,  8, i7,  7, i9]]
-    
-
-  /**
-   * Arto Inkala's ["World's Hardest Sudoku"](
-   * https://www.conceptispuzzles.com/index.aspx?uri=info/article/424)
-   * has a solution.
-   */
-  hard_puzzle:
-    [_]Num -> Bit
-  hard_puzzle
-       [    a2, a3, a4, a5, a6, a7, a8, a9,
-        b1, b2,         b5, b6, b7, b8, b9,
-        c1,     c3, c4,     c6,     c8, c9,
-        d1,     d3, d4, d5,     d7, d8, d9,
-        e1, e2, e3, e4,             e8, e9,
-        f1, f2, f3,     f5, f6, f7,     f9,
-        g1, g2,     g4, g5, g6, g7,        
-        h1, h2,         h5, h6, h7,     h9,
-        i1,     i3, i4, i5, i6,     i8, i9] =
-    valid
-      [[ 8, a2, a3, a4, a5, a6, a7, a8, a9],
-       [b1, b2,  3,  6, b5, b6, b7, b8, b9],
-       [c1,  7, c3, c4,  9, c6,  2, c8, c9],
-       [d1,  5, d3, d4, d5,  7, d7, d8, d9],
-       [e1, e2, e3, e4,  4,  5,  7, e8, e9],
-       [f1, f2, f3,  1, f5, f6, f7,  3, f9],
-       [g1, g2,  1, g4, g5, g6, g7,  6,  8],
-       [h1, h2,  8,  5, h5, h6, h7,  1, h9],
-       [i1,  9, i3, i4, i5, i6,  4, i8, i9]]
-
-  /** a solution to the "World's Hardest Sudoku" */
-  hard_solution:
-    Board
-  hard_solution =
-      [[8, 1, 2, 7, 5, 3, 6, 4, 9],
-       [9, 4, 3, 6, 8, 2, 1, 7, 5],
-       [6, 7, 5, 4, 9, 1, 2, 8, 3],
-       [1, 5, 4, 2, 3, 7, 8, 9, 6],
-       [3, 6, 9, 8, 4, 5, 7, 2, 1],
-       [2, 8, 7, 1, 6, 9, 5, 3, 4],
-       [5, 2, 1, 9, 7, 4, 3, 6, 8],
-       [4, 3, 8, 5, 2, 6, 9, 1, 7],
-       [7, 9, 6, 3, 1, 8, 4, 5, 2]]
-
-  /** The "World's Hardest Sudoku" has a unique solution. */
-  hard_unique:
-    [_]Num -> Bit
-  property hard_unique
-       [    a2, a3, a4, a5, a6, a7, a8, a9,
-        b1, b2,         b5, b6, b7, b8, b9,
-        c1,     c3, c4,     c6,     c8, c9,
-        d1,     d3, d4, d5,     d7, d8, d9,
-        e1, e2, e3, e4,             e8, e9,
-        f1, f2, f3,     f5, f6, f7,     f9,
-        g1, g2,     g4, g5, g6, g7,        
-        h1, h2,         h5, h6, h7,     h9,
-        i1,     i3, i4, i5, i6,     i8, i9] =
-    valid hard_solution /\ (solution == hard_solution \/ ~ valid solution)
-      where
-        solution =
-          [[ 8, a2, a3, a4, a5, a6, a7, a8, a9],
-           [b1, b2,  3,  6, b5, b6, b7, b8, b9],
-           [c1,  7, c3, c4,  9, c6,  2, c8, c9],
-           [d1,  5, d3, d4, d5,  7, d7, d8, d9],
-           [e1, e2, e3, e4,  4,  5,  7, e8, e9],
-           [f1, f2, f3,  1, f5, f6, f7,  3, f9],
-           [g1, g2,  1, g4, g5, g6, g7,  6,  8],
-           [h1, h2,  8,  5, h5, h6, h7,  1, h9],
-           [i1,  9, i3, i4, i5, i6,  4, i8, i9]]
-
-
-  private
-    /** sequence comprising all Sudoku `Num`s */
-    _NUMS: Group
-    _NUMS = [1..9]
-
-    /** whether sequence `G` contains element `x` */
-    _contains:
-      {a,n} fin n => Cmp a => [n]a -> a -> Bit
-    _contains G x =
-      any ((==) x) G
-
-    /**
-     * whether list `G` and list `H` mutually contain the same items
-     * (are permutations if lists comprise unique elements)
-     */
-    _permutes: {a,n} (Cmp a, fin n) => [n]a -> [n]a -> Bit
-    _permutes G H =
-      all _containsG H
-        where
-          _containsG x = _contains G x
-
-    /** whether `Group` `G` permutes `_NUMS` */
-    _check:
-      Group -> Bit
-    _check G =
-      _permutes G _NUMS
+    * whether finite sequences `G` and `H` mutually contain the same items
+    * (are permutations if they each contain no duplicates)
+    */
+  permutes:
+    {a, n}
+    (Cmp a, fin n) =>
+    [n]a -> [n]a -> Bit
+  permutes G H =
+    all (contains G) H

--- a/specs/Misc/Sudoku.cry
+++ b/specs/Misc/Sudoku.cry
@@ -1,0 +1,194 @@
+/* *
+ * Sudoku spec extracted from [Solving Sudoku Using Cryptol](
+ *   https://galois.com/blog/2009/03/solving-sudoku-using-cryptol/
+ * ) and updated to Cryptol 2.8.1
+ */
+module Misc::Sudoku where
+  /** number in [1..9] */
+  type Num = [width 9]
+
+  /** row, column, or 3x3 square of `Num` */
+  type Group = [9]Num
+
+  /** 9x9 grid of `Num` (Sudoku) */
+  type Board = [9]Group
+
+
+  /** whether a full `Board` is valid */
+  valid:
+    Board -> Bit
+  valid rows =
+    all _check (rows # columns # squares)
+      where
+        columns = transpose rows
+        regions = transpose [ groupBy`{3} row
+                            | row <- rows ]
+        squares = [ join sq 
+                  | sq <- groupBy`{3} (join regions) ]
+
+  /**
+   * The easy puzzle in [Solving Sudoku Using Cryptol](
+   * https://galois.com/blog/2009/03/solving-sudoku-using-cryptol)
+   * has a solution.
+   */
+  easy_puzzle:
+    [_]Num -> Bit
+  easy_puzzle
+      [a1,     a3,     a5, a6,         a9,
+       b1,         b4, b5,     b7,     b9,
+       c2,     c4, c5, c6, c7, c8, c9    ,
+       d1, d2,     d4,     d6, d7, d8    ,
+       e1, e2, e3,     e5,     e7, e8, e9,
+       f2, f3, f4,     f6,     f8, f9    ,
+       g1, g2, g3, g4, g5, g6,     g8    ,
+       h1,     h3,     h5, h6,         h9,
+       i1,         i4, i5,     i7,     i9] =
+    valid solution
+      where
+        solution = 
+          [[a1,  9, a3,  7, a5, a6,  8,  6, a9],
+           [b1,  3,  1, b4, b5,  5, b7,  2, b9],
+           [ 8, c2,  6, c4, c5, c6, c7, c8, c9],
+           [d1, d2,  7, d4,  5, d6, d7, d8,  6],
+           [e1, e2, e3,  3, e5,  7, e7, e8, e9],
+           [ 5, f2, f3, f4,  1, f6,  7, f8, f9],
+           [g1, g2, g3, g4, g5, g6,  1, g8,  9],
+           [h1,  2, h3,  6, h5, h6,  3,  5, h9],
+           [i1,  5,  4, i4, i5,  8, i7,  7, i9]]
+
+  /** a solution to the easy puzzle */
+  easy_solution:
+    Board
+  easy_solution =
+    [[2, 9, 5, 7, 4, 3, 8, 6, 1],
+     [4, 3, 1, 8, 6, 5, 9, 2, 7],
+     [8, 7, 6, 1, 9, 2, 5, 4, 3],
+     [3, 8, 7, 4, 5, 9, 2, 1, 6],
+     [6, 1, 2, 3, 8, 7, 4, 9, 5],
+     [5, 4, 9, 2, 1, 6, 7, 3, 8],
+     [7, 6, 3, 5, 2, 4, 1, 8, 9],
+     [9, 2, 8, 6, 7, 1, 3, 5, 4],
+     [1, 5, 4, 9, 3, 8, 6, 7, 2]]
+
+  /** The easy puzzle has a unique solution. */
+  easy_unique:
+    [_]Num -> Bit
+  property easy_unique
+      [a1,     a3,     a5, a6,         a9,
+       b1,         b4, b5,     b7,     b9,
+       c2,     c4, c5, c6, c7, c8, c9    ,
+       d1, d2,     d4,     d6, d7, d8    ,
+       e1, e2, e3,     e5,     e7, e8, e9,
+       f2, f3, f4,     f6,     f8, f9    ,
+       g1, g2, g3, g4, g5, g6,     g8    ,
+       h1,     h3,     h5, h6,         h9,
+       i1,         i4, i5,     i7,     i9] =
+    valid easy_solution /\ (solution == easy_solution \/ ~ valid solution)
+      where
+        solution = 
+          [[a1,  9, a3,  7, a5, a6,  8,  6, a9],
+           [b1,  3,  1, b4, b5,  5, b7,  2, b9],
+           [ 8, c2,  6, c4, c5, c6, c7, c8, c9],
+           [d1, d2,  7, d4,  5, d6, d7, d8,  6],
+           [e1, e2, e3,  3, e5,  7, e7, e8, e9],
+           [ 5, f2, f3, f4,  1, f6,  7, f8, f9],
+           [g1, g2, g3, g4, g5, g6,  1, g8,  9],
+           [h1,  2, h3,  6, h5, h6,  3,  5, h9],
+           [i1,  5,  4, i4, i5,  8, i7,  7, i9]]
+    
+
+  /**
+   * Arto Inkala's ["World's Hardest Sudoku"](
+   * https://www.conceptispuzzles.com/index.aspx?uri=info/article/424)
+   * has a solution.
+   */
+  hard_puzzle:
+    [_]Num -> Bit
+  hard_puzzle
+       [    a2, a3, a4, a5, a6, a7, a8, a9,
+        b1, b2,         b5, b6, b7, b8, b9,
+        c1,     c3, c4,     c6,     c8, c9,
+        d1,     d3, d4, d5,     d7, d8, d9,
+        e1, e2, e3, e4,             e8, e9,
+        f1, f2, f3,     f5, f6, f7,     f9,
+        g1, g2,     g4, g5, g6, g7,        
+        h1, h2,         h5, h6, h7,     h9,
+        i1,     i3, i4, i5, i6,     i8, i9] =
+    valid
+      [[ 8, a2, a3, a4, a5, a6, a7, a8, a9],
+       [b1, b2,  3,  6, b5, b6, b7, b8, b9],
+       [c1,  7, c3, c4,  9, c6,  2, c8, c9],
+       [d1,  5, d3, d4, d5,  7, d7, d8, d9],
+       [e1, e2, e3, e4,  4,  5,  7, e8, e9],
+       [f1, f2, f3,  1, f5, f6, f7,  3, f9],
+       [g1, g2,  1, g4, g5, g6, g7,  6,  8],
+       [h1, h2,  8,  5, h5, h6, h7,  1, h9],
+       [i1,  9, i3, i4, i5, i6,  4, i8, i9]]
+
+  /** a solution to the "World's Hardest Sudoku" */
+  hard_solution:
+    Board
+  hard_solution =
+      [[8, 1, 2, 7, 5, 3, 6, 4, 9],
+       [9, 4, 3, 6, 8, 2, 1, 7, 5],
+       [6, 7, 5, 4, 9, 1, 2, 8, 3],
+       [1, 5, 4, 2, 3, 7, 8, 9, 6],
+       [3, 6, 9, 8, 4, 5, 7, 2, 1],
+       [2, 8, 7, 1, 6, 9, 5, 3, 4],
+       [5, 2, 1, 9, 7, 4, 3, 6, 8],
+       [4, 3, 8, 5, 2, 6, 9, 1, 7],
+       [7, 9, 6, 3, 1, 8, 4, 5, 2]]
+
+  /** The "World's Hardest Sudoku" has a unique solution. */
+  hard_unique:
+    [_]Num -> Bit
+  property hard_unique
+       [    a2, a3, a4, a5, a6, a7, a8, a9,
+        b1, b2,         b5, b6, b7, b8, b9,
+        c1,     c3, c4,     c6,     c8, c9,
+        d1,     d3, d4, d5,     d7, d8, d9,
+        e1, e2, e3, e4,             e8, e9,
+        f1, f2, f3,     f5, f6, f7,     f9,
+        g1, g2,     g4, g5, g6, g7,        
+        h1, h2,         h5, h6, h7,     h9,
+        i1,     i3, i4, i5, i6,     i8, i9] =
+    valid hard_solution /\ (solution == hard_solution \/ ~ valid solution)
+      where
+        solution =
+          [[ 8, a2, a3, a4, a5, a6, a7, a8, a9],
+           [b1, b2,  3,  6, b5, b6, b7, b8, b9],
+           [c1,  7, c3, c4,  9, c6,  2, c8, c9],
+           [d1,  5, d3, d4, d5,  7, d7, d8, d9],
+           [e1, e2, e3, e4,  4,  5,  7, e8, e9],
+           [f1, f2, f3,  1, f5, f6, f7,  3, f9],
+           [g1, g2,  1, g4, g5, g6, g7,  6,  8],
+           [h1, h2,  8,  5, h5, h6, h7,  1, h9],
+           [i1,  9, i3, i4, i5, i6,  4, i8, i9]]
+
+
+  private
+    /** sequence comprising all Sudoku `Num`s */
+    _NUMS: Group
+    _NUMS = [1..9]
+
+    /** whether sequence `G` contains element `x` */
+    _contains:
+      {a,n} fin n => Cmp a => [n]a -> a -> Bit
+    _contains G x =
+      any ((==) x) G
+
+    /**
+     * whether list `G` and list `H` mutually contain the same items
+     * (are permutations if lists comprise unique elements)
+     */
+    _permutes: {a,n} (Cmp a, fin n) => [n]a -> [n]a -> Bit
+    _permutes G H =
+      all _containsG H
+        where
+          _containsG x = _contains G x
+
+    /** whether `Group` `G` permutes `_NUMS` */
+    _check:
+      Group -> Bit
+    _check G =
+      _permutes G _NUMS


### PR DESCRIPTION
The previously referenced [Sudoku example](https://galois.com/blog/2009/03/solving-sudoku-using-cryptol/) from Galois, Inc. has a broken link to what was presumably their Cryptol 1 spec.  This branch updates the spec to Cryptol 2 and adds a hard puzzle as well as proofs of uniqueness.