### PR TITLE
Added `--rm` option (remove container on exit) to Docker instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -32,7 +32,7 @@ user-mode solutions.)*
 ```
 $ docker pull cryptolcourse/cryptol
 ...
-$ docker run -it cryptolcourse/cryptol
+$ docker run --rm -it cryptolcourse/cryptol
 ┏━╸┏━┓╻ ╻┏━┓╺┳╸┏━┓╻
 ┃  ┣┳┛┗┳┛┣━┛ ┃ ┃ ┃┃
 ┗━╸╹┗╸ ╹ ╹   ╹ ┗━┛┗━╸
@@ -48,7 +48,7 @@ Cryptol> :quit
 ```sh
 $ docker pull cryptolcourse/saw
 ...
-$ docker run -it cryptolcourse/saw
+$ docker run --rm -it cryptolcourse/saw
  ┏━━━┓━━━┓━┓━┓━┓
  ┃ ━━┓ ╻ ┃ ┃ ┃ ┃
  ┣━━ ┃ ╻ ┃┓ ╻ ┏┛
@@ -69,8 +69,8 @@ sawscript> :quit
 Details:
 - Instructions for installing `docker` on your system can be found at
 [https://docs.docker.com/get-docker](https://docs.docker.com/get-docker).
-- `docker run -it` indicates that the commands are to be run in an interactive
-TTY.
+- `docker run --rm -it` indicates that the commands are to be run in an interactive
+TTY, and the generated container is to be removed after use.
 - Version tags `0.5` and `2.8.0` are needed because a `latest` alias
 has not been set for these images.
 - If you are currently in the root of this repository, you can use
@@ -263,7 +263,7 @@ labs::Demos::OneTimePad>
 
 ### Docker (Linux)
 ```sh
-.../cryptol-course> docker run --read-only --mount type=bind,src=$(pwd),dst=/mnt/cryptol-course --env CRYPTOLPATH=/mnt/cryptol-course -it cryptolcourse/cryptol
+.../cryptol-course> docker run --rm --read-only --mount type=bind,src=$(pwd),dst=/mnt/cryptol-course --env CRYPTOLPATH=/mnt/cryptol-course -it cryptolcourse/cryptol
 Loading module Cryptol
 Cryptol> :m labs::Demos::OneTimePad
 Loading module labs::Demos::OneTimePad
@@ -272,7 +272,7 @@ labs::Demos::OneTimePad>
 
 ### Docker (Windows)
 ```sh
-...\cryptol-course> docker run --read-only --mount type=bind,src=%CD%,dst=/mnt/cryptol-course --env CRYPTOLPATH=/mnt/cryptol-course -it cryptolcourse/cryptol
+...\cryptol-course> docker run --rm --read-only --mount type=bind,src=%CD%,dst=/mnt/cryptol-course --env CRYPTOLPATH=/mnt/cryptol-course -it cryptolcourse/cryptol
 Loading module Cryptol
 Cryptol> :m labs::Demos::OneTimePad
 Loading module labs::Demos::OneTimePad


### PR DESCRIPTION
Without `--rm`, containers persist after exiting the Cryptol (or SAW) interpreter.  Each `docker run` creates a new container.  So the options are to add this `--rm` option or to resume a container generated by a previous `docker run` instruction.  The latter is easier.

To see which containers persist, one can run `docker ps -a`, and each one can be removed, e.g. `docker rm persnickety_ferret`, or all stopped containers can be removed via `docker container prune`.