### PR TITLE
Improvements to Cryptoproofs lab

### DIFF
--- a/labs/CryptoProofs/CryptoProofs.md
+++ b/labs/CryptoProofs/CryptoProofs.md
@@ -271,6 +271,11 @@ be used to prove that a function is injective.
 Show that, for any given key, `DES.encrypt` is injective
 (collision-free) with respect to plaintext.
 
+Technically, `DES.encrypt` (for any given key) is also *surjective*
+(*onto*) due to the fact that its domain and range are the same (The
+set of all possible 64-bit vectors.) A function that is both injective
+and surjective is called *bijective*.
+
 *Hint*: Use the Boolector prover. (Even then, this proof may take a
 few minutes!)
 

--- a/labs/CryptoProofs/CryptoProofs.md
+++ b/labs/CryptoProofs/CryptoProofs.md
@@ -58,7 +58,9 @@ module labs::CryptoProofs::CryptoProofs where
 
 ## 1. DES
 
-To start, we'll analyze the DES (Data Encryption Standard) algorithm. Let's take a moment to familiarize ourselves with how it works.
+To start, we'll analyze the DES (Data Encryption Standard)
+algorithm. Let's take a moment to familiarize ourselves with how it
+works.
 
 First, we import it.
 
@@ -75,14 +77,15 @@ Loading module specs::Primitive::Symmetric::Cipher::Block::DES
 Loading module labs::CryptoProofs::CryptoProofs
 ```
 
-First, we'll take a look at the type of the DES encryption function.
+Next, we'll take a look at the type of the DES encryption function.
 
 ```shell
 labs::CryptoProofs::CryptoProofs> :t DES.encrypt
 DES.encrypt : [64] -> [64] -> [64]
 ```
 
-DES takes two 64-bit values and returns a 64-bit value. (The key comes first and then the plaintext.) Let's encrypt something with DES.
+DES takes two 64-bit values and returns a 64-bit value. (The key comes
+first and then the plaintext.) Let's encrypt something with DES.
 
 ```shell
 labs::CryptoProofs::CryptoProofs> DES.encrypt 0x752979387592cb70 0x1122334455667788
@@ -100,27 +103,36 @@ Now that we have DES working, let's analyze it!
 
 ## 2. Five Killer Apps
 
-For the rest of the lab, we'll be looking at some of the types of questions you can ask (and often answer!) using Cryptol's powerful automated theorem proving capabilities. These are important questions that one might ask about a cryptographic algorithm along with a generic "one-liner" Cryptol invocation. (Don't worry if you don't understand these yet.)
+For the rest of the lab, we'll be looking at some of the types of
+questions you can ask (and often answer!) using Cryptol's powerful
+automated theorem proving capabilities. These are important questions
+that one might ask about a cryptographic algorithm along with a
+generic "one-liner" Cryptol invocation. (Don't worry if you don't
+understand these yet.)
 
 | Proof | Invocation |
 |-|-|
 | Function reversal | `:sat \x -> f x == y` |
 | Proof of inversion | `:prove \x -> g (f x) == x` |
-| Collision detection | `:sat \x y -> f x == f y /\ x != y` |
 | Proof of injectivity | `:prove \x y -> x != y ==> f x != f y` |
+| Collision detection | `:sat \x y -> f x == f y /\ x != y` |
 | Equivalence checking | `:prove \x -> f x == g x` |
 
 Each subsection below will explore one of these questions in-depth.
 
 ### 2.1 Function Reversal
 
-It may be interesting to explore whether a particular cryptographic function can be reversed. Some examples of usage:
+It may be interesting to explore whether a particular cryptographic
+function can be reversed. Some examples of usage:
 
-* Attempt to reverse a hash function. This is called a preimage attack. (Of course, strong cryptographic hash functions are designed to resist this type of analysis.)
+* Attempt to reverse a hash function. This is called a preimage
+  attack. (Of course, strong cryptographic hash functions are designed
+  to resist this type of analysis.)
 * Carry out decryption when all you have is the encryption function.
 * In general, find an input given an output!
 
-We'll start with an example where we reverse the following simple function:
+We'll start with an example where we reverse the following simple
+function:
 
 ```cryptol
 /** square - multiplies an Integer by itself */
@@ -130,7 +142,8 @@ square x = x * x
 ```
 
 
-Now we can reverse it from the REPL. Let's use the solver to find a square root using only a squaring function!
+Now we can reverse it from the REPL. Let's use the solver to find a
+square root using only a squaring function!
 
 ```shell
 labs::CryptoProofs::CryptoProofs> :sat \x -> square x == 1764
@@ -138,7 +151,8 @@ labs::CryptoProofs::CryptoProofs> :sat \x -> square x == 1764
 (Total Elapsed Time: 0.021s, using "Z3")
 ```
 
-Let's take a closer look at this query, which makes use of a *lambda* (anonymous/unnamed/on-the-fly) function. Here's the breakdown:
+Let's take a closer look at this query, which makes use of a *lambda*
+(anonymous/unnamed/on-the-fly) function. Here's the breakdown:
 
 |Function Reversal||||
 |-|-|-|-|
@@ -152,14 +166,18 @@ Cryptol](https://github.com/GaloisInc/cryptol/blob/master/docs/ProgrammingCrypto
 
 **EXERCISE** 2.1.1 Reverse DES.encrypt
 
-Given the following key and ciphertext, find the plaintext using only the solver and the `DES.encrypt` function. To do this, head over to the Cryptol interpreter, load up the module, and use the `:sat` command similar to the example above.
+Given the following key and ciphertext, find the plaintext using only
+the solver and the `DES.encrypt` function. To do this, head over to
+the Cryptol interpreter, load up the module, and use the `:sat`
+command similar to the example above.
 
 ```cryptol
 known_key = 0x752979387592cb70
 known_ct = 0xf2930290ea4db580
 ```
 
-Note: For whatever reason, the default Z3 solver has trouble with this one. Try one of the other solvers, such as yices:
+Note: For whatever reason, the default Z3 solver has trouble with this
+one. Try one of the other solvers, such as YICES:
 
 ```shell
 labs::CryptoProofs::CryptoProofs> :s prover=yices
@@ -175,19 +193,26 @@ labs::CryptoProofs::CryptoProofs> :s prover=any
 
 **EXERCISE** 2.1.2 Breaking DES
 
-Given the following matched plaintext and ciphertext, ask the solver to find the key. Will this work? Why or why not? (*Hint: see plaintext.*) Note that you can stop the solver at any time by hitting `ctrl-c`.
+Given the following matched plaintext and ciphertext, ask the solver
+to find the key. Will this work? Why or why not? (*Hint*: see
+plaintext.) Note that you can stop the solver at any time by hitting
+`ctrl-c`.
 
 ```cryptol
 matched_pt = join "tootough"
 matched_ct = 0x95d07f8a72707733
 ```
 
-To make this solvable, try it again with the first six bytes of key provided: `0x1234567890ab`.
+To make this solvable, try it again with the first six bytes of key
+provided: `0x1234567890ab`.
 
 
 ### 2.2 Proof of Inversion
 
-For symmetric ciphers, it is necessary that the decrypt function *inverts* the encrypt function. (That is, it restores the ciphertext to the original plaintext.) It is easy to express this property in Cryptol.
+For symmetric ciphers, it is necessary that the decrypt function
+*inverts* the encrypt function. (That is, it restores the ciphertext
+to the original plaintext.) It is easy to express this property in
+Cryptol.
 
 Consider the following functions `f` and `g`:
 
@@ -198,7 +223,9 @@ g: Integer -> Integer
 g x = (x - 2) / 3
 ```
 
-We want to prove that function `g` inverts function `f`; that is, applying `g` to the result of `f x` gets `x` back. Here's the invocation:
+We want to prove that function `g` inverts function `f`; that is,
+applying `g` to the result of `f x` gets `x` back. Here's the
+invocation:
 
 ```shell
 labs::CryptoProofs::CryptoProofs> :prove \x -> g (f x) == x
@@ -216,62 +243,109 @@ Here's the breakdown of this proof:
 
 **EXERCISE** 2.2.1 The other direction
 
-Our example proof showed that `g` inverts `f` for all inputs. Does this work the other way around? Try it! If the proof fails, it will provide a *counterexample*. Use the counterexample to understand what went wrong.
+Our example proof showed that `g` inverts `f` for all inputs. Does
+this work the other way around? Try it! If the proof fails, it will
+provide a *counterexample*. Use the counterexample to understand what
+went wrong.
 
 
 **EXERCISE** 2.2.2 DES inversion
 
-Use Cryptol to prove that `DES.encrypt` and `DES.decrypt` are inverses for all possible inputs. Show both directions.
+Use Cryptol to prove that `DES.encrypt` and `DES.decrypt` are inverses
+for all possible inputs. Show both directions.
 
-*Hint*: Lambda functions can take more than one input, just like normal functions! For example: `\x y z -> x+y+z`
+*Hint*: Lambda functions can take more than one input, just like
+normal functions! For example: `\x y z -> x+y+z`
 
 *Hint*: For fastest results, use the `abc` prover.
 
 
-### 2.3 Collision Detection
+### 2.3 Proof of Injectivity
 
-In cryptography, a *collision* occurs when two different inputs produce the same output. For some cryptographic functions, such as pseudo-random number generators (PRNGs), it may be desirable to demonstrate an absence of collisions. In other functions, such as cryptographic hash functions, collisions are inevitable, but should be difficult to discover. It is easy in Cryptol to ask the solver to search for collisions. (Though finding a solution may not be possible.)
+A function for which every input generates a distinct output is
+referred to in mathematics as *injective* or *one-to-one*. Cryptol can
+be used to prove that a function is injective.
 
-**EXERCISE** 2.3.1 DES Key Collisions
+**EXERCISE** 2.3.1 DES Injectivity
 
-Use the solver to find two different keys and a plaintext such that both keys encrypt that plaintext to the same ciphertext.
+Show that, for any given key, `DES.encrypt` is injective
+(collision-free) with respect to plaintext.
 
-### 2.4 Proof of Injectivity
+*Hint*: Use the Boolector prover. (Even then, this proof may take a
+few minutes!)
 
-The flip-side of collision detection is proving an absence of collisions. That is, proving that every input generates a distinct output. A function with this property is referred to in mathematics as *injective* or *one-to-one*.
+*Hint*: Consider using the implication operator `==>`
 
-**EXERCISE** 2.4.1 DES Injectivity
 
-Show that, for any given key, `DES.encrypt` is injective (collision-free) with respect to plaintext.
+### 2.4 Collision Detection
 
-*Hint* Use the boolector theorem prover. (Even then, this proof may take a few minutes!)
+In cryptography, a *collision* occurs when two different inputs
+produce the same output. (That is, the function is *not* injective.)
+For some cryptographic functions, such as pseudo-random number
+generators (PRNGs), it may be desirable to demonstrate an absence of
+collisions. In other functions, such as cryptographic hash functions,
+collisions are inevitable, but should be difficult to discover. It is
+easy in Cryptol to ask the solver to search for collisions. (Though
+finding a solution may not be possible.)
 
-*Hint* Consider using the implication operator (Type `:h (==>)` for more information.)
+**EXERCISE** 2.4.1 DES Key Collisions
+
+Use the solver to find two different keys and a single plaintext such
+that both keys encrypt that plaintext to the same ciphertext.
 
 
 ### 2.5 Equivalence Checking
 
-It's inevitable that there are collisions over the set of all key/plaintext pairs in DES, but it may be surprising that they're easy to find with Cryptol's solver. We now know that the two keys you just found encrypt one particular plaintext to the same ciphertext; more concerning would be if they perform the same transformation on *all* plaintexts. Such keys are called *equivalent* keys.
+It's inevitable that there are collisions over the set of all
+key/plaintext pairs in DES, but it may be surprising that they're easy
+to find with Cryptol's solver. We now know that the two keys you just
+found encrypt one particular plaintext to the same ciphertext; more
+concerning would be if they perform the same transformation on *all*
+plaintexts. Such keys are called *equivalent* keys.
 
-One of the most powerful uses of Cryptol's theorem proving technology is the ability to show equivalence of two different functions for all possible inputs.
+One of the most powerful uses of Cryptol's theorem proving technology
+is the ability to show equivalence of two different functions for all
+possible inputs.
 
 **EXERCISE** 2.5.1 DES Equivalent Keys
 
-Attempt to prove that the two keys you just found are equivalent keys. That is, prove that these two keyed DES functions are equivalent for all plaintext inputs. *Hint:* Use the abc prover.
+Prove that the two keys you just found are equivalent keys. That is,
+prove that these two keyed DES functions are equivalent for *all*
+plaintext inputs.
+
+*Hint*: Use the `abc` prover.
 
 
 **EXERCISE** 2.5.2 DES Parity Bits
 
-Having equivalent keys is often considered a weakness in an a cipher. However, in the case of DES, it turns out that this is a result of a design choice. The lowest bit of each byte of a DES key is actually a [parity bit](https://en.wikipedia.org/wiki/Parity_bit) that is completely ignored by the cipher itself. For DES, the parity bit ensures that the total number of 1-bits in each byte is odd.
+Having equivalent keys is often considered a weakness in an a
+cipher. However, in the case of DES, it turns out that this is a
+result of a design choice. The lowest bit of each byte of a DES key is
+actually a [parity bit](https://en.wikipedia.org/wiki/Parity_bit) that
+is completely ignored by the cipher itself. For DES, the parity bit
+ensures that the total number of 1-bits in each byte is odd.
 
-Write a function `DESFixParity : [64] -> [64]` that takes any 64-bit vector and returns the equivalent DES key with properly computed parity bits.
+Write a function `DESFixParity : [64] -> [64]` that takes any 64-bit
+vector and returns the equivalent DES key with properly computed
+parity bits. (This is the first and only time in this lab that you'll
+need to edit this file directly.)
+
+```cryptol
+DESFixParity : [64] -> [64]
+DESFixParity = zero // Replace "zero" with your code
+```
 
 
 **EXERCISE** 2.5.3 Proving DES Key Equivalence
 
-Use the function `DESFixParity` that you wrote above to show that DES completely ignores parity bits. That is, prove that the DES encryption that allows all 64-bit keys is equivalent to the DES encryption function that first corrects the parity bits on those keys.
+Use the function `DESFixParity` that you wrote above to show that DES
+completely ignores parity bits. That is, prove that the DES encryption
+that allows all 64-bit keys is equivalent to the DES encryption
+function that first corrects the parity bits on those keys.
 
-Given that this proof passes, what is the actual maximum key strength of DES in terms of bits?
+Given that this proof passes, what is the actual maximum key strength
+of DES in terms of bits?
+
 
 # The end
 

--- a/labs/CryptoProofs/CryptoProofsAnswers.md
+++ b/labs/CryptoProofs/CryptoProofsAnswers.md
@@ -321,13 +321,18 @@ normal functions! For example: `\x y z -> x+y+z`
 ### 2.3 Proof of Injectivity
 
 A function for which every input generates a distinct output is
-referred to in mathematics as *injective* or *one-to-one*. Cryptol can
+referred to in mathematics as *injective* (*one-to-one*). Cryptol can
 be used to prove that a function is injective.
 
 **EXERCISE** 2.3.1 DES Injectivity
 
 Show that, for any given key, `DES.encrypt` is injective
-(collision-free) with respect to plaintext.
+with respect to plaintext.
+
+Technically, `DES.encrypt` (for any given key) is also *surjective*
+(*onto*) due to the fact that its domain and range are the same (The
+set of all possible 64-bit vectors.) A function that is both injective
+and surjective is called *bijective*.
 
 *Hint*: Use the Boolector prover. (Even then, this proof may take a
 few minutes!)

--- a/labs/CryptoProofs/CryptoProofsAnswers.md
+++ b/labs/CryptoProofs/CryptoProofsAnswers.md
@@ -58,7 +58,9 @@ module labs::CryptoProofs::CryptoProofsAnswers where
 
 ## 1. DES
 
-To start, we'll analyze the DES (Data Encryption Standard) algorithm. Let's take a moment to familiarize ourselves with how it works.
+To start, we'll analyze the DES (Data Encryption Standard)
+algorithm. Let's take a moment to familiarize ourselves with how it
+works.
 
 First, we import it.
 
@@ -75,14 +77,15 @@ Loading module specs::Primitive::Symmetric::Cipher::Block::DES
 Loading module labs::CryptoProofs::CryptoProofsAnswers
 ```
 
-First, we'll take a look at the type of the DES encryption function.
+Next, we'll take a look at the type of the DES encryption function.
 
 ```shell
 labs::CryptoProofs::CryptoProofsAnswers> :t DES.encrypt
 DES.encrypt : [64] -> [64] -> [64]
 ```
 
-DES takes two 64-bit values and returns a 64-bit value. (The key comes first and then the plaintext.) Let's encrypt something with DES.
+DES takes two 64-bit values and returns a 64-bit value. (The key comes
+first and then the plaintext.) Let's encrypt something with DES.
 
 ```shell
 labs::CryptoProofs::CryptoProofs> DES.encrypt 0x752979387592cb70 0x1122334455667788
@@ -100,27 +103,36 @@ Now that we have DES working, let's analyze it!
 
 ## 2. Five Killer Apps
 
-For the rest of the lab, we'll be looking at some of the types of questions you can ask (and often answer!) using Cryptol's powerful automated theorem proving capabilities. These are important questions that one might ask about a cryptographic algorithm along with a generic "one-liner" Cryptol invocation. (Don't worry if you don't understand these yet.)
+For the rest of the lab, we'll be looking at some of the types of
+questions you can ask (and often answer!) using Cryptol's powerful
+automated theorem proving capabilities. These are important questions
+that one might ask about a cryptographic algorithm along with a
+generic "one-liner" Cryptol invocation. (Don't worry if you don't
+understand these yet.)
 
 | Proof | Invocation |
 |-|-|
 | Function reversal | `:sat \x -> f x == y` |
 | Proof of inversion | `:prove \x -> g (f x) == x` |
-| Collision detection | `:sat \x y -> f x == f y /\ x != y` |
 | Proof of injectivity | `:prove \x y -> x != y ==> f x != f y` |
+| Collision detection | `:sat \x y -> f x == f y /\ x != y` |
 | Equivalence checking | `:prove \x -> f x == g x` |
 
 Each subsection below will explore one of these questions in-depth.
 
 ### 2.1 Function Reversal
 
-It may be interesting to explore whether a particular cryptographic function can be reversed. Some examples of usage:
+It may be interesting to explore whether a particular cryptographic
+function can be reversed. Some examples of usage:
 
-* Attempt to reverse a hash function. This is called a preimage attack. (Of course, strong cryptographic hash functions are designed to resist this type of analysis.)
+* Attempt to reverse a hash function. This is called a preimage
+  attack. (Of course, strong cryptographic hash functions are designed
+  to resist this type of analysis.)
 * Carry out decryption when all you have is the encryption function.
 * In general, find an input given an output!
 
-We'll start with an example where we reverse the following simple function:
+We'll start with an example where we reverse the following simple
+function:
 
 ```cryptol
 /** square - multiplies an Integer by itself */
@@ -130,7 +142,8 @@ square x = x * x
 ```
 
 
-Now we can reverse it from the REPL. Let's use the solver to find a square root using only a squaring function!
+Now we can reverse it from the REPL. Let's use the solver to find a
+square root using only a squaring function!
 
 ```shell
 labs::CryptoProofs::CryptoProofs> :sat \x -> square x == 1764
@@ -138,7 +151,8 @@ labs::CryptoProofs::CryptoProofs> :sat \x -> square x == 1764
 (Total Elapsed Time: 0.021s, using "Z3")
 ```
 
-Let's take a closer look at this query, which makes use of a *lambda* (anonymous/unnamed/on-the-fly) function. Here's the breakdown:
+Let's take a closer look at this query, which makes use of a *lambda*
+(anonymous/unnamed/on-the-fly) function. Here's the breakdown:
 
 |Function Reversal||||
 |-|-|-|-|
@@ -152,14 +166,18 @@ Cryptol](https://github.com/GaloisInc/cryptol/blob/master/docs/ProgrammingCrypto
 
 **EXERCISE** 2.1.1 Reverse DES.encrypt
 
-Given the following key and ciphertext, find the plaintext using only the solver and the `DES.encrypt` function. To do this, head over to the Cryptol interpreter, load up the module, and use the `:sat` command similar to the example above.
+Given the following key and ciphertext, find the plaintext using only
+the solver and the `DES.encrypt` function. To do this, head over to
+the Cryptol interpreter, load up the module, and use the `:sat`
+command similar to the example above.
 
 ```cryptol
 known_key = 0x752979387592cb70
 known_ct = 0xf2930290ea4db580
 ```
 
-Note: For whatever reason, the default Z3 solver has trouble with this one. Try one of the other solvers, such as YICES:
+Note: For whatever reason, the default Z3 solver has trouble with this
+one. Try one of the other solvers, such as YICES:
 
 ```shell
 labs::CryptoProofs::CryptoProofsAnswers> :s prover=yices
@@ -185,14 +203,18 @@ labs::CryptoProofs::CryptoProofsAnswers> :s prover=any
 
 **EXERCISE** 2.1.2 Breaking DES
 
-Given the following matched plaintext and ciphertext, ask the solver to find the key. Will this work? Why or why not? (*Hint: see plaintext.*) Note that you can stop the solver at any time by hitting `ctrl-c`.
+Given the following matched plaintext and ciphertext, ask the solver
+to find the key. Will this work? Why or why not? (*Hint*: see
+plaintext.) Note that you can stop the solver at any time by hitting
+`ctrl-c`.
 
 ```cryptol
 matched_pt = join "tootough"
 matched_ct = 0x95d07f8a72707733
 ```
 
-To make this solvable, try it again with the first six bytes of key provided: `0x1234567890ab`.
+To make this solvable, try it again with the first six bytes of key
+provided: `0x1234567890ab`.
 
 > Solution:
 >
@@ -206,15 +228,18 @@ To make this solvable, try it again with the first six bytes of key provided: `0
 > and large amounts of compute power, but not by a single computer
 > running a SAT solver.
 >```shell
->labs::CryptoProofs::CryptoProofsAnswers> :sat \key -> DES.encrypt (0x1234567890AB # key) matched_pt == matched_ct
->(\key -> DES.encrypt (0x1234567890ab # key)
->                     matched_pt == matched_ct)
->  0x1236 = True
->(Total Elapsed Time: 4.764s, using "Yices")
+>labs::CryptoProofs::CryptoProofsAnswers> :sat \key -> DES.encrypt key matched_pt == matched_ct /\ take key == 0x1234567890ab
+>(\key -> DES.encrypt key
+>                     matched_pt == matched_ct /\ take key == 0x1234567890ab)
+>  0x1234567890ab1236 = True
+>(Total Elapsed Time: 4.496s, using Z3)
 
 ### 2.2 Proof of Inversion
 
-For symmetric ciphers, it is necessary that the decrypt function *inverts* the encrypt function. (That is, it restores the ciphertext to the original plaintext.) It is easy to express this property in Cryptol.
+For symmetric ciphers, it is necessary that the decrypt function
+*inverts* the encrypt function. (That is, it restores the ciphertext
+to the original plaintext.) It is easy to express this property in
+Cryptol.
 
 Consider the following functions `f` and `g`:
 
@@ -225,7 +250,9 @@ g: Integer -> Integer
 g x = (x - 2) / 3
 ```
 
-We want to prove that function `g` inverts function `f`; that is, applying `g` to the result of `f x` gets `x` back. Here's the invocation:
+We want to prove that function `g` inverts function `f`; that is,
+applying `g` to the result of `f x` gets `x` back. Here's the
+invocation:
 
 ```shell
 labs::CryptoProofs::CryptoProofsAnswers> :prove \x -> g (f x) == x
@@ -243,7 +270,10 @@ Here's the breakdown of this proof:
 
 **EXERCISE** 2.2.1 The other direction
 
-Our example proof showed that `g` inverts `f` for all inputs. Does this work the other way around? Try it! If the proof fails, it will provide a *counterexample*. Use the counterexample to understand what went wrong.
+Our example proof showed that `g` inverts `f` for all inputs. Does
+this work the other way around? Try it! If the proof fails, it will
+provide a *counterexample*. Use the counterexample to understand what
+went wrong.
 
 > Solution:
 >
@@ -253,8 +283,8 @@ Our example proof showed that `g` inverts `f` for all inputs. Does this work the
 >(Total Elapsed Time: 0.003s, using Yices)
 >```
 >
->Here we see that Cryptol has found that not only is our theorem false,
->but provides a counterexample that we can analyze to see why.
+>Here we see that Cryptol has found that not only is our theorem
+>false, but provides a counterexample that we can analyze to see why.
 >Let's look a little closer.
 >
 >```shell
@@ -262,15 +292,17 @@ Our example proof showed that `g` inverts `f` for all inputs. Does this work the
 >0
 >```
 >
->The reason this doesn't work is because `g` is defined over the integers.
->Therefore, the division operator `(/)` computes integer division,
->so the expected result of `1/3` is rounded down to `0`.
+>The reason this doesn't work is because `g` is defined over the
+>integers.  Therefore, the division operator `(/)` computes integer
+>division, so the expected result of `1/3` is rounded down to `0`.
 
 **EXERCISE** 2.2.2 DES inversion
 
-Use Cryptol to prove that `DES.encrypt` and `DES.decrypt` are inverses for all possible inputs. Show both directions.
+Use Cryptol to prove that `DES.encrypt` and `DES.decrypt` are inverses
+for all possible inputs. Show both directions.
 
-*Hint*: Lambda functions can take more than one input, just like normal functions! For example: `\x y z -> x+y+z`
+*Hint*: Lambda functions can take more than one input, just like
+normal functions! For example: `\x y z -> x+y+z`
 
 *Hint*: For fastest results, use the `abc` prover.
 
@@ -286,13 +318,45 @@ Use Cryptol to prove that `DES.encrypt` and `DES.decrypt` are inverses for all p
 >(Total Elapsed Time: 3.582s, using "ABC")
 >```
 
-### 2.3 Collision Detection
+### 2.3 Proof of Injectivity
 
-In cryptography, a *collision* occurs when two different inputs produce the same output. For some cryptographic functions, such as pseudo-random number generators (PRNGs), it may be desirable to demonstrate an absence of collisions. In other functions, such as cryptographic hash functions, collisions are inevitable, but should be difficult to discover. It is easy in Cryptol to ask the solver to search for collisions. (Though finding a solution may not be possible.)
+A function for which every input generates a distinct output is
+referred to in mathematics as *injective* or *one-to-one*. Cryptol can
+be used to prove that a function is injective.
 
-**EXERCISE** 2.3.1 DES Key Collisions
+**EXERCISE** 2.3.1 DES Injectivity
 
-Use the solver to find two different keys and a plaintext such that both keys encrypt that plaintext to the same ciphertext.
+Show that, for any given key, `DES.encrypt` is injective
+(collision-free) with respect to plaintext.
+
+*Hint*: Use the Boolector prover. (Even then, this proof may take a
+few minutes!)
+
+*Hint*: Consider using the implication operator `==>`
+
+> Solution:
+>```shell
+>labs::CryptoProofs::CryptoProofsAnswers> :s prover=boolector
+>labs::CryptoProofs::CryptoProofsAnswers> :prove \k p1 p2 -> p1 != p2 ==> DES.encrypt k p1 != DES.encrypt k p2
+>Q.E.D.
+>(Total Elapsed Time: 58.598s, using "Boolector")
+>```
+
+### 2.4 Collision Detection
+
+In cryptography, a *collision* occurs when two different inputs
+produce the same output. (That is, the function is *not* injective.)
+For some cryptographic functions, such as pseudo-random number
+generators (PRNGs), it may be desirable to demonstrate an absence of
+collisions. In other functions, such as cryptographic hash functions,
+collisions are inevitable, but should be difficult to discover. It is
+easy in Cryptol to ask the solver to search for collisions. (Though
+finding a solution may not be possible.)
+
+**EXERCISE** 2.4.1 DES Key Collisions
+
+Use the solver to find two different keys and a single plaintext such
+that both keys encrypt that plaintext to the same ciphertext.
 
 > Solution:
 >```shell
@@ -303,35 +367,26 @@ Use the solver to find two different keys and a plaintext such that both keys en
 >(Total Elapsed Time: 1.258s, using "Yices")
 >```
 
-### 2.4 Proof of Injectivity
-
-The flip-side of collision detection is proving an absence of collisions. That is, proving that every input generates a distinct output. A function with this property is referred to in mathematics as *injective* or *one-to-one*.
-
-**EXERCISE** 2.4.1 DES Injectivity
-
-Show that, for any given key, `DES.encrypt` is injective (collision-free) with respect to plaintext.
-
-*Hint* Use the Boolector theorem prover. (Even then, this proof may take a few minutes!)
-
-*Hint* Consider using the implication operator `==>`
-
-> Solution:
->```shell
->labs::CryptoProofs::CryptoProofsAnswers> :s prover=boolector
->labs::CryptoProofs::CryptoProofsAnswers> :prove \k p1 p2 -> p1 != p2 ==> DES.encrypt k p1 != DES.encrypt k p2
->Q.E.D.
->(Total Elapsed Time: 58.598s, using "Boolector")
->```
-
 ### 2.5 Equivalence Checking
 
-It's inevitable that there are collisions over the set of all key/plaintext pairs in DES, but it may be surprising that they're easy to find with Cryptol's solver. We now know that the two keys you just found encrypt one particular plaintext to the same ciphertext; more concerning would be if they perform the same transformation on *all* plaintexts. Such keys are called *equivalent* keys.
+It's inevitable that there are collisions over the set of all
+key/plaintext pairs in DES, but it may be surprising that they're easy
+to find with Cryptol's solver. We now know that the two keys you just
+found encrypt one particular plaintext to the same ciphertext; more
+concerning would be if they perform the same transformation on *all*
+plaintexts. Such keys are called *equivalent* keys.
 
-One of the most powerful uses of Cryptol's theorem proving technology is the ability to show equivalence of two different functions for all possible inputs.
+One of the most powerful uses of Cryptol's theorem proving technology
+is the ability to show equivalence of two different functions for all
+possible inputs.
 
 **EXERCISE** 2.5.1 DES Equivalent Keys
 
-Attempt to prove that the two keys you just found are equivalent keys. That is, prove that these two keyed DES functions are equivalent for all plaintext inputs. *Hint* Use the `abc` prover.
+Prove that the two keys you just found are equivalent keys. That is,
+prove that these two keyed DES functions are equivalent for *all*
+plaintext inputs.
+
+*Hint*: Use the `abc` prover.
 
 > Solution:
 >```shell
@@ -343,9 +398,17 @@ Attempt to prove that the two keys you just found are equivalent keys. That is, 
 
 **EXERCISE** 2.5.2 DES Parity Bits
 
-Having equivalent keys is often considered a weakness in an a cipher. However, in the case of DES, it turns out that this is a result of a design choice. The lowest bit of each byte of a DES key is actually a [parity bit](https://en.wikipedia.org/wiki/Parity_bit) that is completely ignored by the cipher itself. For DES, the parity bit ensures that the total number of 1-bits in each byte is odd.
+Having equivalent keys is often considered a weakness in an a
+cipher. However, in the case of DES, it turns out that this is a
+result of a design choice. The lowest bit of each byte of a DES key is
+actually a [parity bit](https://en.wikipedia.org/wiki/Parity_bit) that
+is completely ignored by the cipher itself. For DES, the parity bit
+ensures that the total number of 1-bits in each byte is odd.
 
-Write a function `DESFixParity : [64] -> [64]` that takes any 64-bit vector and returns the equivalent DES key with properly computed parity bits.
+Write a function `DESFixParity : [64] -> [64]` that takes any 64-bit
+vector and returns the equivalent DES key with properly computed
+parity bits. (This is the first and only time in this lab that you'll
+need to edit this file directly.)
 
 > Solution:
 
@@ -361,9 +424,13 @@ DESFixParity key = join fixed_bytes
 
 **EXERCISE** 2.5.3 Proving DES Key Equivalence
 
-Use the function `DESFixParity` that you wrote above to show that DES completely ignores parity bits. That is, prove that the DES encryption that allows all 64-bit keys is equivalent to the DES encryption function that first corrects the parity bits on those keys.
+Use the function `DESFixParity` that you wrote above to show that DES
+completely ignores parity bits. That is, prove that the DES encryption
+that allows all 64-bit keys is equivalent to the DES encryption
+function that first corrects the parity bits on those keys.
 
-Given that this proof passes, what is the actual maximum key strength of DES in terms of bits?
+Given that this proof passes, what is the actual maximum key strength
+of DES in terms of bits?
 
 > Solution
 >```shell
@@ -371,7 +438,8 @@ Given that this proof passes, what is the actual maximum key strength of DES in 
 >Q.E.D.
 >(Total Elapsed Time: 0.807s, using ABC)
 >```
-> Since 8 of the 64 bits are ignored, DES has a maximum key strength of 56 bits.
+> Since 8 of the 64 bits are ignored, DES has a maximum key strength
+> of 56 bits.
 
 # The end
 


### PR DESCRIPTION
Improved flow by switching the order of the injectivity and collisions labs. Now that last few labs all form an investigation into the DES parity bit thing.

Improved the "break DES" solution.

Split the long lines.

Minor consistency fixes.