### PR TITLE
Fixed loading twice

### DIFF
--- a/labs/CryptoProofs/CryptoProofs.md
+++ b/labs/CryptoProofs/CryptoProofs.md
@@ -68,14 +68,14 @@ First, we import it.
 import specs::Primitive::Symmetric::Cipher::Block::DES
 ```
 
-Now, from the command line, load this module.
+When you loaded the module, these lines should have been printed:
 
 ```shell
-Cryptol> :m labs::CryptoProofs::CryptoProofs
 Loading module specs::Primitive::Symmetric::Cipher::Block::Cipher
 Loading module specs::Primitive::Symmetric::Cipher::Block::DES
 Loading module labs::CryptoProofs::CryptoProofs
 ```
+In reverse order: the third line says that this module has been loaded.  Since it imported the DES module, Cryptol helpfully tells you that DES has been loaded.  Since DES imported the Cipher module, Cryptol tells you that too.
 
 Next, we'll take a look at the type of the DES encryption function.
 


### PR DESCRIPTION
The markdown said to import this module twice.  Not a big correction, but I changed it so no one would think it was necessary.  I also explained that this module imported DES which imported Cipher.