### PR TITLE
Fixed sums code

### DIFF
--- a/labs/KeyWrapping/KeyWrapping.md
+++ b/labs/KeyWrapping/KeyWrapping.md
@@ -332,7 +332,7 @@ iterative process. For instance, we **could** find a list of partial
 sums from the sequence `[1..10]` as follows:
 
 ```shell
-Cryptol> [0] # [ x + partial | x <- [1..10] | partial <- sums]
+Cryptol> sums where sums = [0] # [ x + partial | x <- [1..10] | partial <- sums]
 [0, 1, 3, 6, 10, 15, 21, 28, 36, 45, 55]
 ```
 

--- a/labs/KeyWrapping/KeyWrappingAnswers.md
+++ b/labs/KeyWrapping/KeyWrappingAnswers.md
@@ -331,7 +331,7 @@ iterative process. For instance, we **could** find a list of partial
 sums from the sequence `[1..10]` as follows:
 
 ```shell
-Cryptol> [0] # [ x + partial | x <- [1..10] | partial <- sums]
+Cryptol> sums where sums = [0] # [ x + partial | x <- [1..10] | partial <- sums]
 [0, 1, 3, 6, 10, 15, 21, 28, 36, 45, 55]
 ```
 


### PR DESCRIPTION
The `sums` code never defines `sums`, and so results in an error when run.  Fixed it.