### PR TITLE
Corrected snippets in `labs/Demos/Cryptol`

### DIFF
--- a/labs/Demos/Cryptol/Caesar.md
+++ b/labs/Demos/Cryptol/Caesar.md
@@ -28,6 +28,8 @@ running in the `cryptol-course` directory with:
 
 ```shell
 Cryptol> :m labs::Demos::Cryptol::Caesar
+Loading module Cryptol
+Loading module labs::Demos::Cryptol::Caesar
 ```
 
 We start by defining a new module for this lab and importing some accessory
@@ -59,6 +61,7 @@ caesar msg = map rot3 msg
 ```
 
 ```shell
+labs::Demos::Cryptol::Caesar> :s prover=abc
 labs::Demos::Cryptol::Caesar> :s ascii=on
 labs::Demos::Cryptol::Caesar> caesar "ATTACK AT DAWN"
 "XQQXZH XQ AXTK"
@@ -118,7 +121,7 @@ property charIsAtIndex = indexCorrect alphabet
 ```shell
 labs::Demos::Cryptol::Caesar> :prove charIsAtIndex
 Q.E.D.
-(Total Elapsed Time: 0.072s, using "Z3")
+(Total Elapsed Time: 0.072s, using ABC)
 ```
 
 The property even holds for other sequences, repeating or not:
@@ -126,10 +129,10 @@ The property even holds for other sequences, repeating or not:
 ```shell
 labs::Demos::Cryptol::Caesar> :prove \(A : [64]Char) -> indexCorrect A
 Q.E.D.
-(Total Elapsed Time: 1.172s, using "Z3")
-labs::Demos::Cryptol::Caesar> :prove \(L : [33]Integer) -> indexCorrect L
+(Total Elapsed Time: 1.172s, using ABC)
+labs::Demos::Cryptol::Caesar> :prove \(L : [33][32]) -> indexCorrect L
 Q.E.D.
-(Total Elapsed Time: 0.347s, using "Z3")
+(Total Elapsed Time: 0.347s, using ABC)
 ```
 
 But to work for a Caesar cipher, each character in the alphabet needs
@@ -258,10 +261,10 @@ property recovery_14 = recovery`{14}
 ```shell
 labs::Demos::Cryptol::Caesar> :prove recovery_4
 Q.E.D.
-(Total Elapsed Time: 4.226s, using "Z3")
+(Total Elapsed Time: 0.245s, using ABC)
 labs::Demos::Cryptol::Caesar> :prove recovery_14
 Q.E.D.
-(Total Elapsed Time: 28.246s, using "Z3")
+(Total Elapsed Time: 0.956s, using ABC)
 ```
 
 
@@ -305,13 +308,13 @@ solving...
 
 ```shell
 labs::Demos::Cryptol::Caesar> :sat \k -> encrypt k "ILLUMINATI CONFIRMED" == "NQQZRNSFYN HTSKNWRJI"
+Satisfiable
 (\k -> encrypt k "ILLUMINATI CONFIRMED" == "NQQZRNSFYN HTSKNWRJI")
   21 = True
-(Total Elapsed Time: 0.089s, using "Z3")
+(Total Elapsed Time: 0.089s, using ABC)
 ```
 
-
-## Conclusion
+# Conclusion
 
 You came, you saw, and you conquered the Caesar cipher in Cryptol.
 Ave, Caesar!

--- a/labs/Demos/Cryptol/NQueens.md
+++ b/labs/Demos/Cryptol/NQueens.md
@@ -30,6 +30,8 @@ running in the `cryptol-course` directory with:
 
 ```shell
 Cryptol> :m labs::Demos::Cryptol::NQueens
+Loading module Cryptol
+Loading module labs::Demos::Cryptol::NQueens
 ```
 
 We start by defining a new module for this lab and importing some accessory

--- a/labs/Demos/Cryptol/OneTimePad.md
+++ b/labs/Demos/Cryptol/OneTimePad.md
@@ -29,6 +29,8 @@ running in the `cryptol-course` directory with:
 
 ```shell
 Cryptol> :m labs::Demos::Cryptol::OneTimePad
+Loading module Cryptol
+Loading module labs::Demos::Cryptol::OneTimePad
 ```
 
 We start by defining a new module for this lab and importing some accessory
@@ -201,7 +203,7 @@ labs::Demos::Cryptol::OneTimePad> :h encrypt
 Cool. Let's do a quick sanity check:
 
 ```shell
-labs::Demos::Cryptol::OneTimePad> (decrypt psk ct)
+labs::Demos::Cryptol::OneTimePad> decrypt psk ct
 "HELLO"
 ```
 
@@ -269,9 +271,10 @@ reasonably have been "GOODBYE". Then Eve can exploit Cryptol to
 deduce the pre-shared key Bob just used:
 
 ```shell
-labs::Demos::Cryptol::OneTimePad> :sat \psk -> (encrypt psk pt2) == ct2
-(\psk -> (encrypt (psk : String 7) pt2) == ct2) "ZUGESAG" = True
-(Total Elapsed Time: 0.042s, using Z3)
+labs::Demos::Cryptol::OneTimePad> :sat \psk2 -> (encrypt`{7} psk2 pt2) == ct2
+Satisfiable
+(\psk2 -> (encrypt`{7} psk2 pt2) == ct2) "ZUGESAG" = True
+(Total Elapsed Time: 0.044s, using "Z3")
 ```
 
 (That "`->`" syntax defines a [lambda function](
@@ -288,14 +291,14 @@ stash it and try it on the message Bob received earlier:
 labs::Demos::Cryptol::OneTimePad> it
 {result = True, arg1 = "ZUGESAG"}
 labs::Demos::Cryptol::OneTimePad> let psk' = it.arg1
-labs::Demos::Cryptol::OneTimePad> :sat \pt -> (encrypt psk' pt) == ct
-(\pt -> (encrypt psk' pt) == ct) "HELLO" = True
+labs::Demos::Cryptol::OneTimePad> :sat \pt3 -> (encrypt psk' pt3) == ct
+(\pt3 -> (encrypt psk' pt3) == ct) "HELLO" = True
 (Total Elapsed Time: 0.028s, using Z3)
 ```
 
 Hello!!! So much for communications security...
 
-## Review
+# Conclusion
 
 Well that was fun. We have clearly expressed the one-time pad using
 Cryptol, demonstrated it on some test cases, verified some simple

--- a/labs/Demos/Cryptol/OneTimePad.md
+++ b/labs/Demos/Cryptol/OneTimePad.md
@@ -272,7 +272,6 @@ deduce the pre-shared key Bob just used:
 
 ```shell
 labs::Demos::Cryptol::OneTimePad> :sat \psk2 -> (encrypt`{7} psk2 pt2) == ct2
-Satisfiable
 (\psk2 -> (encrypt`{7} psk2 pt2) == ct2) "ZUGESAG" = True
 (Total Elapsed Time: 0.044s, using "Z3")
 ```

--- a/labs/Demos/Cryptol/Sudoku.md
+++ b/labs/Demos/Cryptol/Sudoku.md
@@ -31,6 +31,8 @@ running in the `cryptol-course` directory with:
 
 ```shell
 Cryptol> :m labs::Demos::Cryptol::Sudoku
+Loading module Cryptol
+Loading module labs::Demos::Cryptol::Sudoku
 ```
 
 We start by defining a new module for this lab and importing some accessory
@@ -272,6 +274,7 @@ f x = x*x - 7*x + 12 == 0
 > solution to the quadratic equation `x^^2 - 7x + 12 = 0`. We have:
 
 ```shell
+labs::Demos::Cryptol::Sudoku> :s base=10
 labs::Demos::Cryptol::Sudoku> :sat f
 f 4 = True
 (Total Elapsed Time: 0.151s, using "Z3")
@@ -483,13 +486,12 @@ hard_puzzle
 ```
 
 ```shell
+labs::Demos::Cryptol::Sudoku> :s base=10
 labs::Demos::Cryptol::Sudoku> :sat hard_puzzle
 hard_puzzle
-  [0x1, 0x2, 0x7, 0x5, 0x3, 0x6, 0x4, 0x9, 0x9, 0x4, 0x8, 0x2, 0x1,
-   0x7, 0x5, 0x6, 0x5, 0x4, 0x1, 0x8, 0x3, 0x1, 0x4, 0x2, 0x3, 0x8,
-   0x9, 0x6, 0x3, 0x6, 0x9, 0x8, 0x2, 0x1, 0x2, 0x8, 0x7, 0x6, 0x9,
-   0x5, 0x4, 0x5, 0x2, 0x9, 0x7, 0x4, 0x3, 0x4, 0x3, 0x2, 0x6, 0x9,
-   0x7, 0x7, 0x6, 0x3, 0x1, 0x8, 0x5, 0x2] = True
+  [1, 2, 7, 5, 3, 6, 4, 9, 9, 4, 8, 2, 1, 7, 5, 6, 5, 4, 1, 8, 3, 1,
+   4, 2, 3, 8, 9, 6, 3, 6, 9, 8, 2, 1, 2, 8, 7, 6, 9, 5, 4, 5, 2, 9,
+   7, 4, 3, 4, 3, 2, 6, 9, 7, 7, 6, 3, 1, 8, 5, 2] = True
 (Total Elapsed Time: 2.031s, using "Z3")
 ```
 


### PR DESCRIPTION
This PR corrects snippets in `labs/Demos` based on running the experimental [Markdown Snippet Extractor](https://github.com/weaversa/cryptol-course/pull/111).