### PR TITLE
Complied to VS Code tasks.json schema

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.0.0",
+    "version": "2.0.0",
     "tasks": [
         {
             "label": "Cryptol",
@@ -7,7 +7,7 @@
             "command": "cryptol",
             "problemMatcher": []
         },
-            {
+        {
             "label": "Software Analysis Workbench",
             "type": "shell",
             "command": "saw",


### PR DESCRIPTION
Evidently a `tasks.json` file is supposed to have the `version` field set to `"2.0.0"`, per its ["schema"](https://code.visualstudio.com/docs/editor/tasks-appendix).  This isn't the place to specify version numbering for individual projects.