### PR TITLE
Amended labs for consistency against CI test

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -74,7 +74,10 @@ If a terminal window appears with the Cryptol logo, you're done. Feel
 free to load the next lab into the interpreter by typing:
 
 ```Xcryptol session
+Loading module Cryptol
 Cryptol> :m labs::Overview::Overview
+Loading module Cryptol
+Loading module labs::Overview::Overview
 ```
 
 You may now start using Visual Studio Code to work through the
@@ -109,7 +112,7 @@ for user-mode solutions.)*
 The Cryptol and *optional* SAW docker images can be downloaded by
 issuing the following Docker commands in your computer's terminal.
 
-```shell
+```
 $ docker pull cryptolcourse/cryptol
 ...
 $ docker pull cryptolcourse/saw
@@ -129,7 +132,7 @@ pasting a simple command into a shell prompt.
 Once Homebrew is installed, Cryptol (along with its `z3` dependency)
 can be installed via:
 
-```shell
+```
 brew update && brew install cryptol
 ```
 
@@ -155,7 +158,7 @@ you downloaded should be placed in your system path.
 For CentOS, Ubuntu, or MacOS, the whole process would look something
 like (depending on the which OS variant you have):
 
-```shell
+```
 $ curl -fsSL https://github.com/GaloisInc/saw-script/releases/download/v0.5/saw-0.5-Ubuntu14.04-64.tar.gz | tar -xz
 $ export PATH=$(pwd)/saw-0.5-Ubuntu14.04-64/bin:${PATH}
 ```
@@ -186,7 +189,7 @@ your system path.
 For CentOS, Ubuntu, or MacOS, the whole process would look something
 like (depending on which OS build and version you download):
 
-```shell
+```
 $ curl -fsSL https://github.com/Z3Prover/z3/releases/download/z3-4.8.8/z3-4.8.8-x64-osx-10.14.6.zip -o z3-4.8.8-x64-osx-10.14.6.zip
 $ unzip -j z3-4.8.8-x64-osx-10.14.6.zip -d z3-4.8.8
 $ export PATH=$(pwd)/z3-4.8.8:${PATH}
@@ -239,22 +242,30 @@ is used by both Cryptol and SAW.
 
 ### Using Docker on Linux and MacOS
 
-```shell
+```
 .../cryptol-course> docker run --rm -it --read-only --mount type=bind,src=$(pwd),dst=/mnt/cryptol-course --env CRYPTOLPATH=/mnt/cryptol-course cryptolcourse/cryptol
     ...
 Loading module Cryptol
+```
+
+```Xcryptol session
 Cryptol> :module labs::Demos::Cryptol::OneTimePad
+Loading module Cryptol
 Loading module labs::Demos::Cryptol::OneTimePad
 labs::Demos::Cryptol::OneTimePad>
 ```
 
 ### Using Docker on Windows 10
 
-```shell
+```
 ...\cryptol-course> docker run --rm -it --read-only --mount type=bind,src=%CD%,dst=/mnt/cryptol-course --env CRYPTOLPATH=/mnt/cryptol-course cryptolcourse/cryptol
     ...
 Loading module Cryptol
+```
+
+```Xcryptol session
 Cryptol> :module labs::Demos::Cryptol::OneTimePad
+Loading module Cryptol
 Loading module labs::Demos::Cryptol::OneTimePad
 labs::Demos::Cryptol::OneTimePad>
 ```
@@ -266,10 +277,13 @@ First ensure that the cryptol intepreter is started in the
 CRYPTOLPATH to point to that directory. Then, use the `:module`
 command from within Cryptol to load the lab.
 
-```shell
+```
 .../cryptol-course$ cryptol
     ...
 Loading module Cryptol
+```
+
+```Xcryptol session
 Cryptol> :module labs::Demos::Cryptol::OneTimePad
 Loading module Cryptol
 Loading module labs::Demos::Cryptol::OneTimePad

--- a/labs/CRC/CRC.md
+++ b/labs/CRC/CRC.md
@@ -39,6 +39,7 @@ interpreter. Load this module from within the Cryptol interpreter running
 in the `cryptol-course` directory with:
 
 ```Xcryptol session
+Loading module Cryptol
 Cryptol> :m labs::CRC::CRC
 Loading module Cryptol
 Loading module labs::CRC::CRC
@@ -250,7 +251,6 @@ CRC32_C = CRC G undefined undefined undefined undefined
 
 property CRC32_CTest =
     CRC32_C testM == 0x22620404
-
 ```
 
 

--- a/labs/CRC/CRCAnswers.md
+++ b/labs/CRC/CRCAnswers.md
@@ -39,6 +39,7 @@ interpreter. Load this module from within the Cryptol interpreter running
 in the `cryptol-course` directory with:
 
 ```Xcryptol session
+Loading module Cryptol
 Cryptol> :m labs::CRC::CRCAnswers
 Loading module Cryptol
 Loading module labs::CRC::CRCAnswers
@@ -239,7 +240,6 @@ CRC32_BZIP2 = CRC G 0xffffffff 0xffffffff False False
 
 property CRC32_BZIP2Test =
     CRC32_BZIP2 testM == 0x459DEE61
-
 ```
 
 
@@ -251,7 +251,6 @@ CRC32_C = CRC G 0xffffffff 0xffffffff True True
 
 property CRC32_CTest =
     CRC32_C testM == 0x22620404
-
 ```
 
 

--- a/labs/CryptoProofs/CryptoProofs.md
+++ b/labs/CryptoProofs/CryptoProofs.md
@@ -40,6 +40,7 @@ interpreter. Load this module from within the Cryptol interpreter
 running in the `cryptol-course` directory with:
 
 ```Xcryptol session
+Loading module Cryptol
 Cryptol> :m labs::CryptoProofs::CryptoProofs
 Loading module Cryptol
 Loading module specs::Primitive::Symmetric::Cipher::Block::Cipher
@@ -81,6 +82,7 @@ When you loaded the `labs::CryptoProofs::CryptoProofs` module, these
 lines should have been printed:
 
 ```Xcryptol session
+Loading module Cryptol
 Loading module specs::Primitive::Symmetric::Cipher::Block::Cipher
 Loading module specs::Primitive::Symmetric::Cipher::Block::DES
 Loading module labs::CryptoProofs::CryptoProofs
@@ -354,7 +356,6 @@ need to edit this file directly.)
 DESFixParity : [64] -> [64]
 DESFixParity = zero // Replace "zero" with your code
 ```
-
 
 **EXERCISE**: 2.5.3 Proving DES Key Equivalence
 

--- a/labs/CryptoProofs/CryptoProofsAnswers.md
+++ b/labs/CryptoProofs/CryptoProofsAnswers.md
@@ -40,6 +40,7 @@ interpreter. Load this module from within the Cryptol interpreter
 running in the `cryptol-course` directory with:
 
 ```Xcryptol session
+Loading module Cryptol
 Cryptol> :m labs::CryptoProofs::CryptoProofsAnswers
 Loading module Cryptol
 Loading module specs::Primitive::Symmetric::Cipher::Block::Cipher
@@ -80,7 +81,8 @@ import specs::Primitive::Symmetric::Cipher::Block::DES
 When you loaded the `labs::CryptoProofs::CryptoProofsAnswers` module,
 these lines should have been printed:
 
-```Xcryptol session
+```example
+Loading module Cryptol
 Loading module specs::Primitive::Symmetric::Cipher::Block::Cipher
 Loading module specs::Primitive::Symmetric::Cipher::Block::DES
 Loading module labs::CryptoProofs::CryptoProofsAnswers
@@ -233,7 +235,7 @@ provided: `0x1234567890ab`.
 
 > Solution:
 >
->```Xcryptol session
+>```Xcryptol session ci-none
 >labs::CryptoProofs::CryptoProofsAnswers> :sat \key -> DES.encrypt key matched_pt == matched_ct
 >```
 > At this point, the solver hangs, unable to find a solution in any
@@ -344,7 +346,7 @@ be used to prove that a function is injective.
 **EXERCISE**: 2.3.1 DES Injectivity
 
 Show that, for any given key, `DES.encrypt` is injective
-with respect to plaintext.
+(collision-free) with respect to plaintext.
 
 Technically, `DES.encrypt` (for any given key) is also *surjective*
 (*onto*) due to the fact that its domain and range are the same (The
@@ -384,6 +386,7 @@ that both keys encrypt that plaintext to the same ciphertext.
 >```Xcryptol session
 >labs::CryptoProofs::CryptoProofsAnswers> :s prover=yices
 >labs::CryptoProofs::CryptoProofsAnswers> :sat \k1 k2 pt -> k1 != k2 /\ DES.encrypt k1 pt == DES.encrypt k2 pt
+>Satisfiable
 >(\k1 k2 pt -> k1 != k2 /\ DES.encrypt k1 pt == DES.encrypt k2 pt)
 >  0x0000000000000000 0x0100000000000000 0x0000000000000000 = True
 >(Total Elapsed Time: 1.258s, using "Yices")

--- a/labs/Demos/Cryptol/Caesar.md
+++ b/labs/Demos/Cryptol/Caesar.md
@@ -27,6 +27,7 @@ interpreter. Load this module from within the Cryptol interpreter
 running in the `cryptol-course` directory with:
 
 ```Xcryptol session
+Loading module Cryptol
 Cryptol> :m labs::Demos::Cryptol::Caesar
 Loading module Cryptol
 Loading module labs::Demos::Cryptol::Caesar

--- a/labs/Demos/Cryptol/NQueens.md
+++ b/labs/Demos/Cryptol/NQueens.md
@@ -29,6 +29,7 @@ interpreter. Load this module from within the Cryptol interpreter
 running in the `cryptol-course` directory with:
 
 ```Xcryptol session
+Loading module Cryptol
 Cryptol> :m labs::Demos::Cryptol::NQueens
 Loading module Cryptol
 Loading module labs::Demos::Cryptol::NQueens
@@ -192,13 +193,13 @@ The instructions for [1] also work here:
 >
 > To do that,
 >
-> ```Text
+> ```example
 > > :set prover=z3
 > ```
 >
 > or
 >
-> ```Text
+> ```example
 > > :set prover=yices
 > ```
 

--- a/labs/Demos/Cryptol/OneTimePad.md
+++ b/labs/Demos/Cryptol/OneTimePad.md
@@ -28,6 +28,7 @@ interpreter. Load this module from within the Cryptol interpreter
 running in the `cryptol-course` directory with:
 
 ```Xcryptol session
+Loading module Cryptol
 Cryptol> :m labs::Demos::Cryptol::OneTimePad
 Loading module Cryptol
 Loading module labs::Demos::Cryptol::OneTimePad
@@ -242,13 +243,14 @@ type), as reflected in the
 rather sesquipedalian name; let's use tab-completion to prove the
 property:
 
-```Text
+```example
 labs::Demos::Cryptol::OneTimePad> :prove dec<Tab>
 labs::Demos::Cryptol::OneTimePad> :prove decrypt_<Tab>
 labs::Demos::Cryptol::OneTimePad> :prove decrypt_of_encrypt_yields_original_plaintext_8_5<Enter>
 Q.E.D.
 (Total Elapsed Time: 0.028s, using Z3)
 ```
+
 ```Xcryptol session
 labs::Demos::Cryptol::OneTimePad> :prove decrypt_of_encrypt_yields_original_plaintext_8_5
 Q.E.D.

--- a/labs/Demos/Cryptol/Sudoku.md
+++ b/labs/Demos/Cryptol/Sudoku.md
@@ -30,6 +30,7 @@ interpreter. Load this module from within the Cryptol interpreter
 running in the `cryptol-course` directory with:
 
 ```Xcryptol session
+Loading module Cryptol
 Cryptol> :m labs::Demos::Cryptol::Sudoku
 Loading module Cryptol
 Loading module labs::Demos::Cryptol::Sudoku

--- a/labs/Demos/SAW/Bittwiddling/Bittwiddling.md
+++ b/labs/Demos/SAW/Bittwiddling/Bittwiddling.md
@@ -67,6 +67,7 @@ interpreter. Load this module from within the Cryptol interpreter running
 in the `cryptol-course` directory with:
 
 ```Xcryptol session
+Loading module Cryptol
 Cryptol> :m labs::Demos::SAW::Bittwiddling::Bittwiddling
 Loading module Cryptol
 Loading module labs::Demos::SAW::Bittwiddling::Bittwiddling

--- a/labs/Demos/SAW/Bittwiddling/BittwiddlingAnswers.md
+++ b/labs/Demos/SAW/Bittwiddling/BittwiddlingAnswers.md
@@ -67,6 +67,7 @@ interpreter. Load this module from within the Cryptol interpreter running
 in the `cryptol-course` directory with:
 `
 ```Xcryptol session
+Loading module Cryptol
 Cryptol> :m labs::Demos::SAW::Bittwiddling::BittwiddlingAnswers
 Loading module Cryptol
 Loading module labs::Demos::SAW::Bittwiddling::BittwiddlingAnswers

--- a/labs/Interpreter/Interpreter.md
+++ b/labs/Interpreter/Interpreter.md
@@ -37,6 +37,7 @@ interpreter. Load this module from within the Cryptol interpreter running
 in the `cryptol-course` directory with:
 
 ```Xcryptol session
+Loading module Cryptol
 Cryptol> :m labs::Interpreter::Interpreter
 Loading module Cryptol
 Loading module labs::Interpreter::Interpreter
@@ -396,17 +397,20 @@ To load a module by its name (rather than by filename), we use
 The latter is preferred. To set the CRYPTOLPATH variable such that we
 can access the labs and specs here, do this:
 
-```Xcryptol session
+```Xcryptol shell
 $ export CRYPTOLPATH=<path-to-cryptol-course>
-cryptol-course]$ cryptol
+cryptol-course$ cryptol
 ┏━╸┏━┓╻ ╻┏━┓╺┳╸┏━┓╻
 ┃  ┣┳┛┗┳┛┣━┛ ┃ ┃ ┃┃
 ┗━╸╹┗╸ ╹ ╹   ╹ ┗━┛┗━╸
 version 2.9.0
 https://cryptol.net  :? for help
-
 Loading module Cryptol
+```
+
+```Xcryptol session
 Cryptol> :m labs::Interpreter::Interpreter
+Loading module Cryptol
 Loading module labs::Interpreter::Interpreter
 labs::Interpreter::Interpreter>
 ```
@@ -423,7 +427,7 @@ an environment variable called `EDITOR`. For example, if in a Linux
 like environment, the following command will change the default to
 [Emacs](https://www.gnu.org/software/emacs/).
 
-```Xcryptol session
+```Xcryptol shell
 $ export EDITOR="emacs -nw"
 ```
 
@@ -433,9 +437,9 @@ Interpreter commands can be issued directly from the command line, or
 from a batch file. For example, here we issue some commands from the
 command line using the interpreter's `-c` flag:
 
-```Xcryptol session
-$ cryptol -c ":m labs::Interpreter::Interpreter" -c ":s base=10" -c "x + 2"
+```Xcryptol shell
 Loading module Cryptol
+$ cryptol -c ":m labs::Interpreter::Interpreter" -c ":s base=10" -c "x + 2"
 Loading module Cryptol
 Loading module labs::Interpreter::Interpreter
 3
@@ -444,13 +448,12 @@ Loading module labs::Interpreter::Interpreter
 And here we issue the same commands by running the `test.sry` batch
 file using the interpreter's `-b` flag:
 
-```Xcryptol session
+```Xcryptol shell
 $ cat labs/Interpreter/test.sry
 :m labs::Interpreter::Interpreter
 :s base=10
 x + 2
 $ cryptol -b labs/Interpreter/test.sry
-Loading module Cryptol
 Loading module Cryptol
 Loading module labs::Interpreter::Interpreter
 3
@@ -460,7 +463,7 @@ Loading module labs::Interpreter::Interpreter
 
 The last few items covered here (and more) can be found querying Cryptol's usage options via:
 
-```Xcryptol session
+```Xcryptol shell
 $ cryptol --help
 Usage: cryptol [OPTIONS]
   -b FILE     --batch=FILE             run the script provided and exit

--- a/labs/KeyWrapping/KeyWrapping.md
+++ b/labs/KeyWrapping/KeyWrapping.md
@@ -44,6 +44,7 @@ interpreter. Load this module from within the Cryptol interpreter running
 in the `cryptol-course` directory with:
 
 ```Xcryptol session
+Loading module Cryptol
 Cryptol> :m labs::KeyWrapping::KeyWrapping
 Loading module Cryptol
 Loading module specs::Primitive::Symmetric::Cipher::Block::AES::GF28

--- a/labs/KeyWrapping/KeyWrappingAnswers.md
+++ b/labs/KeyWrapping/KeyWrappingAnswers.md
@@ -44,6 +44,7 @@ interpreter. Load this module from within the Cryptol interpreter running
 in the `cryptol-course` directory with:
 
 ```Xcryptol session
+Loading module Cryptol
 Cryptol> :m labs::KeyWrapping::KeyWrappingAnswers
 Loading module Cryptol
 Loading module specs::Primitive::Symmetric::Cipher::Block::AES::GF28

--- a/labs/Language/Basics.md
+++ b/labs/Language/Basics.md
@@ -53,6 +53,7 @@ interpreter. Load this module from within the Cryptol interpreter
 running in the `cryptol-course` directory with:
 
 ```Xcryptol session
+Loading module Cryptol
 Cryptol> :m labs::Language::Basics
 Loading module Cryptol
 Loading module labs::Overview::Overview
@@ -1575,7 +1576,7 @@ correct by printing `Q.E.D.`. This means Cryptol has proven that your
 `R` is correct for all possible inputs (which is either `2^^96` for
 the 32-bit proof or `2^^192` for the 64-bit proof).
 
-```Xcryptol session
+```Xcryptol session ci-none
 labs::Language::Basics> :prove RInverseProperty`{32}
 Q.E.D.
 (Total Elapsed Time: 0.008s, using "Z3")

--- a/labs/LoremIpsum/LoremIpsum.md
+++ b/labs/LoremIpsum/LoremIpsum.md
@@ -31,6 +31,7 @@ interpreter. Load this module from within the Cryptol interpreter
 running in the `cryptol-course` directory with:
 
 ```Xcryptol session
+Loading module Cryptol
 Cryptol> :m labs::LoremIpsum::LoremIpsum
 Loading module Cryptol
 ...

--- a/labs/LoremIpsum/LoremIpsumAnswers.md
+++ b/labs/LoremIpsum/LoremIpsumAnswers.md
@@ -31,6 +31,7 @@ interpreter. Load this module from within the Cryptol interpreter
 running in the `cryptol-course` directory with:
 
 ```Xcryptol session
+Loading module Cryptol
 Cryptol> :m labs::LoremIpsum::LoremIpsumAnswers
 Loading module Cryptol
 Loading module labs::CRC::CRCAnswers

--- a/labs/Overview/Overview.md
+++ b/labs/Overview/Overview.md
@@ -45,6 +45,7 @@ interpreter. Load this module from within the Cryptol interpreter
 running in the `cryptol-course` directory with:
 
 ```Xcryptol session
+Loading module Cryptol
 Cryptol> :m labs::Overview::Overview
 Loading module Cryptol
 Loading module labs::Overview::Overview

--- a/labs/ProjectEuler/ProjectEuler.md
+++ b/labs/ProjectEuler/ProjectEuler.md
@@ -38,6 +38,7 @@ interpreter. Load this module from within the Cryptol interpreter
 running in the `cryptol-course` directory with:
 
 ```Xcryptol session
+Loading module Cryptol
 Cryptol> :m labs::ProjectEuler::ProjectEuler
 Loading module Cryptol
 Loading module labs::ProjectEuler::cipher1

--- a/labs/ProjectEuler/ProjectEulerAnswers.md
+++ b/labs/ProjectEuler/ProjectEulerAnswers.md
@@ -38,6 +38,7 @@ interpreter. Load this module from within the Cryptol interpreter
 running in the `cryptol-course` directory with:
 
 ```Xcryptol session
+Loading module Cryptol
 Cryptol> :m labs::ProjectEuler::ProjectEulerAnswers
 Loading module Cryptol
 Loading module labs::ProjectEuler::cipher1

--- a/labs/Salsa20/Salsa20.md
+++ b/labs/Salsa20/Salsa20.md
@@ -40,6 +40,7 @@ interpreter. Load this module from within the Cryptol interpreter running
 in the `cryptol-course` directory with:
 
 ```Xcryptol session
+Loading module Cryptol
 Cryptol> :m labs::Salsa20::Salsa20
 Loading module Cryptol
 Loading module labs::Salsa20::Salsa20
@@ -298,7 +299,7 @@ than the number of seconds left before the [Sun swallows the
 Earth](https://en.wikipedia.org/wiki/Future_of_Earth). However, if
 you'd prefer to try, Cryptol's `:exhaust` is the command to use.
 
-```Xcryptol session
+```Xcryptol session ci-none
 labs::Salsa20::Salsa20> 2^^256 : Integer
 115792089237316195423570985008687907853269984665640564039457584007913129639936
 labs::Salsa20::Salsa20> :exhaust quarterroundIsInjectiveProp

--- a/labs/Salsa20/Salsa20Answers.md
+++ b/labs/Salsa20/Salsa20Answers.md
@@ -40,6 +40,7 @@ interpreter. Load this module from within the Cryptol interpreter running
 in the `cryptol-course` directory with:
 
 ```Xcryptol session
+Loading module Cryptol
 Cryptol> :m labs::Salsa20::Salsa20Answers
 Loading module Cryptol
 Loading module labs::Salsa20::Salsa20Answers
@@ -298,7 +299,7 @@ than the number of seconds left before the [Sun swallows the
 Earth](https://en.wikipedia.org/wiki/Future_of_Earth). However, if
 you'd prefer to try, Cryptol's `:exhaust` is the command to use.
 
-```Xcryptol session
+```Xcryptol session ci-none
 labs::Salsa20::Salsa20> 2^^256 : Integer
 115792089237316195423570985008687907853269984665640564039457584007913129639936
 labs::Salsa20::Salsa20> :exhaust quarterroundIsInjectiveProp

--- a/labs/Salsa20/Salsa20Props.md
+++ b/labs/Salsa20/Salsa20Props.md
@@ -37,6 +37,7 @@ interpreter. Load this module from within the Cryptol interpreter running
 in the `cryptol-course` directory with:
 
 ```Xcryptol session
+Loading module Cryptol
 Cryptol> :m labs::Salsa20::Salsa20Props
 Loading module Cryptol
 Loading module labs::Salsa20::Salsa20Answers

--- a/labs/Salsa20/Salsa20PropsAnswers.md
+++ b/labs/Salsa20/Salsa20PropsAnswers.md
@@ -37,6 +37,7 @@ interpreter. Load this module from within the Cryptol interpreter running
 in the `cryptol-course` directory with:
 
 ```Xcryptol session
+Loading module Cryptol
 Cryptol> :m labs::Salsa20::Salsa20PropsAnswers
 Loading module Cryptol
 Loading module labs::Salsa20::Salsa20Answers

--- a/labs/SimonSpeck/SimonSpeck.md
+++ b/labs/SimonSpeck/SimonSpeck.md
@@ -32,6 +32,7 @@ interpreter. Load this module from within the Cryptol interpreter
 running in the `cryptol-course` directory with:
 
 ```Xcryptol session
+Loading module Cryptol
 Cryptol> :m labs::SimonSpeck::SimonSpeck
 Loading module Cryptol
 Loading module labs::SimonSpeck::Simon::Simon
@@ -365,7 +366,8 @@ then you should be able to load the `SpeckTestVectors` module also
 located in the `Speck` folder as follows and verify that you have
 correctly implemented the functions:
 
-```Xcryptol session
+```Xcryptol session ci-none
+Loading module Cryptol
 Cryptol> :m labs::SimonSpeck::Speck::SpeckTestVectors
 labs::SimonSpeck::Simon::SpeckTestVectors> :prove all_speck_vectors_pass 
 Q.E.D.


### PR DESCRIPTION
This PR tweaks lab modules such that extracted snippets will pass consistency checks to be integrated into CI.  `Xcryptol session` fences that take too long to complete or capture shell commands outside a Cryptol session were relabeled (by adding `ci-none` and changing just `session` to `shell`, respectively.  Running `.icry` in batch mode outputs a leading `Loading module Cryptol` message, which I represent in snippets above the first `:m` (or `:module`) command of each lab.