### PR TITLE
Reintroduce Yices build to fix issue running container on Windows host

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:buster
 RUN apt-get update \
-    && apt-get install -y libgmp10 libgomp1 libffi6 wget libncurses5 unzip libreadline7 vim emacs-nox sudo git curl \
+    && apt-get install -y libgmp10 libgomp1 libffi6 wget libncurses5 unzip libreadline7 vim emacs-nox git curl \
        make libgmp-dev gperf gcc autoconf \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 COPY --from=galoisinc/saw:0.5 /usr/local/bin /usr/local/bin
@@ -14,9 +14,6 @@ RUN curl -L https://yices.csl.sri.com/releases/2.6.2/yices-2.6.2-src.tar.gz | ta
     && cp build/*/bin/yices_smt2 /usr/local/bin/yices-smt2 \
     && cd .. && rm -rf yices*
 RUN useradd -m -p '' cryptol && chown -R cryptol:cryptol /home/cryptol
-RUN adduser cryptol sudo
-RUN echo "Defaults lecture = never" >> /etc/sudoers \
-    && echo "cryptol ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 USER cryptol
 ENV LANG C.UTF-8
 RUN echo 'export PS1="\$(pwd)> "' >> /home/cryptol/.bashrc


### PR DESCRIPTION
This makes the same changes as @jpziegler's [commit](https://github.com/weaversa/cryptol-course/commit/994d8bd6bddda46616feb9ded1bc77313dc705fb#diff-d41e2ec59f8d1b91106cfb28b42870d5) to build Yices from source, because the binary doesn't work when running the Docker container on a Windows host.  The prior commit got lost in the shuffle when reverting my erroneous merge.