### PR TITLE
Grammar, directory explanation, delete "also"

### DIFF
--- a/labs/Interpreter/Interpreter.md
+++ b/labs/Interpreter/Interpreter.md
@@ -44,15 +44,30 @@ Loading module labs::Interpreter::Interpreter
 labs::Interpreter::Interpreter>
 ```
 
-We start by defining a new module for this lab:
+A Cryptol `module` is a named codeblock within a file.  The module
+name is used when `import`-ing code into a larger Cryptol project, or
+for interactively incorporating the code in the interpreter via the
+`:module` command (described in the [Loading
+Modules](#loading-modules) section below).  A file can only contain
+one module, and the name of the module should match the filename.
+Additionally, the module can have namespace characteristics, separated
+by `::` delimiters.  The namespace values directly correlate with
+directory structure surrounding the file.
+
+In this file, we start by defining a new module for this lab:
 
 ```cryptol
 module labs::Interpreter::Interpreter where
 ```
-You do not need to enter the above into the interpreter; the previous 
-`:m ...` command loaded this literate Cryptol file automatically.  
-In general, you should run `Xcryptol session` commands in the 
-interpreter and leave `cryptol` code alone to be parsed by `:m ...`.
+
+That indicates that this file `Interpreter.md` will be found in the
+directory `labs/Interpreter`.
+
+*(Note: you do not need to enter the `module` instruction into the
+interpreter; the previous `:m ...` command loaded this literate
+Cryptol file automatically.  In general, you should run `Xcryptol
+session` commands in the interpreter and leave `cryptol` code alone to
+be parsed by `:m ...`.)*
 
 # Using the Cryptol interpreter
 
@@ -385,8 +400,12 @@ symbols.
 
 ## Loading Modules
 
-To load a module by its name (rather than by filename), we use
-`:module` (or `:m`). In order for the module to be found, either
+To load a module by its name (rather than by filename), we use the
+`:module` (or `:m`) command. Namespace elements of a module name
+directly correlate with directory structure; e.g., this module
+`labs::Interpreter::Interpreter` maps directly to the file at
+`labs/Interpreter/Interpreter.md`. Thus in order for the module to be
+found, either
 
   1) the Cryptol interpreter must have been started at the same base
      directory as the module, or

--- a/labs/Interpreter/Interpreter.md
+++ b/labs/Interpreter/Interpreter.md
@@ -254,13 +254,13 @@ labs::Interpreter::Interpreter> 10 : Word 32
 0x0000000a
 ```
 
-The next things you'll see with `:b` are some constraint
+The next things you'll see with `:browse` are some constraint
 synonyms. These are helper functions used to express type
 constraints. The ones preloaded into the interpreter unify different
 types of comparison operators to `>=`. This just saves users from
 having to express type constraints using only `>=`.
 
-The next things you'll see with `:b` are some primitive types. These
+The next things you'll see with `:browse` are some primitive types. These
 include comparison and arithmetic operators, type classes, basic
 types, and some type constraints that help with expressing some
 cryptographic type constraints elegantly. These are used when defining
@@ -272,7 +272,7 @@ labs::Interpreter::Interpreter> :t 10 : [width 32]
 (10 : [width 32]) : [6]
 ```
 
-In the last section that you'll see with `:b` are Cryptol's symbols. This
+Cryptol's symbols are given in the last section provided by `:browse`. This
 is where you'll find all of the value operators (as opposed to type
 operators). These are used when defining the value of a function or
 variable. For example, `reverse` can be used to reverse the order of a
@@ -283,7 +283,7 @@ labs::Interpreter::Interpreter> reverse [1, 2, 3] : [3][2]
 [0x3, 0x2, 0x1]
 ```
 
-Each of the items in the environment can be queried using `:h`.
+Each of the items in the environment can be queried using `:help` (`:h` for short).
 
 
 ## Tab Completion and Scrolling

--- a/labs/Interpreter/Interpreter.md
+++ b/labs/Interpreter/Interpreter.md
@@ -49,7 +49,7 @@ name is used when `import`-ing code into a larger Cryptol project, or
 for interactively incorporating the code in the interpreter via the
 `:module` command (described in the [Loading
 Modules](#loading-modules) section below).  A file can only contain
-one module, and the name of the module should match the filename.
+one module, and the name of the module must match the filename.
 Additionally, the module can have namespace characteristics, separated
 by `::` delimiters.  The namespace values directly correlate with
 directory structure surrounding the file.

--- a/labs/Interpreter/Interpreter.md
+++ b/labs/Interpreter/Interpreter.md
@@ -102,7 +102,7 @@ warnShadowing = on
 ```
 
 The most common setting to change is `base`. The default is `base =
-16` which means the interpreter will display bitvectors by printing
+16`, which means the interpreter will display bitvectors by printing
 their hexadecimal representations. For example,
 
 ```Xcryptol session
@@ -112,8 +112,8 @@ labs::Interpreter::Interpreter> 10 : [4]
 0xa
 ```
 
-To make the interpreter display bitvectors in decimal (base 10) type
-`:set base=10`. To change back to hexadecimal type `:set base=16`.
+To make the interpreter display bitvectors in decimal (base 10), type
+`:set base=10`. To change back to hexadecimal, type `:set base=16`.
 
 ```Xcryptol session
 labs::Interpreter::Interpreter> :set base=10
@@ -246,7 +246,7 @@ Type Synonyms
 ```
 
 Type synonyms are helper functions used to express the type of some
-data. For example, The number `10` can be expressed as a 32-bit word
+data. For example, the number `10` can be expressed as a 32-bit word
 via,
 
 ```Xcryptol session
@@ -272,7 +272,7 @@ labs::Interpreter::Interpreter> :t 10 : [width 32]
 (10 : [width 32]) : [6]
 ```
 
-In the last section you'll see with `:b` are Cryptol's symbols. This
+In the last section that you'll see with `:b` are Cryptol's symbols. This
 is where you'll find all of the value operators (as opposed to type
 operators). These are used when defining the value of a function or
 variable. For example, `reverse` can be used to reverse the order of a
@@ -289,8 +289,8 @@ Each of the items in the environment can be queried using `:h`.
 ## Tab Completion and Scrolling
 
 The interpreter supports [TAB
-completion](https://en.wikipedia.org/wiki/Command-line_completion),
-that is, pressing TAB will display all of available symbols. And, if
+completion](https://en.wikipedia.org/wiki/Command-line_completion);
+that is, pressing TAB will display all available symbols. And, if
 you start typing a symbol and then press TAB, the interpreter will
 attempt to complete the symbol you've started typing.
 
@@ -318,7 +318,7 @@ labs::Interpreter::Interpreter> reverse it
 [1, 2, 3]
 ```
 
-Though, now the value of `it` has also become `[1, 2, 3]`. To bind a
+Though, in the same way, now the value of `it` has become `[1, 2, 3]`. To bind a
 value to a name (save it for later) we can use the `let` command. For
 example, here we bind the result of `reverse [1, 2, 3] : [3][2]` to
 `r`, then `reverse r` and show that the result is as expected and that
@@ -334,7 +334,7 @@ labs::Interpreter::Interpreter> r
 [3, 2, 1]
 ```
 
-`let` is very helpful for debugging and program understanding,
+`let` is very helpful for debugging and program understanding;
 however, it can cause confusion (as demonstrated in the simple example
 below). Thus, industrial use of `let` is discouraged.
 
@@ -395,7 +395,7 @@ Symbols
 ```
 
 Here we see that this module provides one type synonym and three
-symbols.
+symbols.  (If your result does not match, try reloading the module.)
 
 
 ## Loading Modules
@@ -405,7 +405,7 @@ To load a module by its name (rather than by filename), we use the
 directly correlate with directory structure; e.g., this module
 `labs::Interpreter::Interpreter` maps directly to the file at
 `labs/Interpreter/Interpreter.md`. Thus in order for the module to be
-found, either
+found (essentially, finding the base directory for that path), either
 
   1) the Cryptol interpreter must have been started at the same base
      directory as the module, or
@@ -441,8 +441,9 @@ labs::Interpreter::Interpreter>
 The Cryptol interpreter supports editing the currently loaded file or
 module via `:e`. However, if no file or module is loaded `:e` will
 allow you to edit the Cryptol prelude, which is very dangerous. When
-you type `:e`, Cryptol will load the current file or module in a text
-editor, and reload the file when the editor is closed. The default
+you type `:e`, Cryptol will open the current file or module in a text
+editor, and will then reload the file into the interpreter when the editor
+is closed. The default
 editor is [vim](https://www.vim.org/), but can be changed via setting
 an environment variable called `EDITOR`. For example, if in a Linux
 like environment, the following command will change the default to

--- a/labs/Interpreter/Interpreter.md
+++ b/labs/Interpreter/Interpreter.md
@@ -350,8 +350,8 @@ labs::Interpreter::Interpreter>
 ```
 
 Here we see that this file contains a module named
-`labs::Interpreter::Interpreter`, which really just describes it's filename
-and directory path from the root of the repository.
+`labs::Interpreter::Interpreter`, which really just describes its filename
+and directory path (labs/Interpreter/Interpreter.md).
 
 We can browse the currently loaded module to see what new symbols it
 provides. Remember that the interpreter supports TAB completion so you
@@ -386,16 +386,18 @@ symbols.
 ## Loading Modules
 
 To load a module by its name (rather than by filename), we use
-`:m`. For this command to work, either
+`:module` (or `:m`). In order for the module to be found, either
 
-  1) the Cryptol interpreter must have been started in the root
-     directory of the module, or
+  1) the Cryptol interpreter must have been started at the same base
+     directory as the module, or
 
-  2) the root directory of the module must be in the CRYPTOLPATH
-     environment variable.
+  2) the (fully-qualified) base directory of the module must be in
+     the CRYPTOLPATH environment variable.
 
-The latter is preferred. To set the CRYPTOLPATH variable such that we
-can access the labs and specs here, do this:
+The CRYPTOLPATH approach is more robust, as it will work no matter
+what directory Cryptol is started in. To set the CRYPTOLPATH variable
+(in Linux) such that we can access the labs and specs for this class,
+do this:
 
 ```Xcryptol shell
 $ export CRYPTOLPATH=<path-to-cryptol-course>


### PR DESCRIPTION
Thing changed
         Explanation
--------------------------------------------------------------------
The default is base = 16, which means…
	Comma is grammatically necessary.

To make the interpreter display bitvectors in decimal (base 10), type :set base=10. To change back to hexadecimal, type :set base=16.
	Commas helpful for parsing verb (vs. noun) meaning of “type”.

For example, the number 10
	Typo, needs lowercase t.

In the last section that you'll see with :b are Cryptol's symbols.
	Added “that” for easier parsing on first read (clarifying “you’ll see...” modifies “section” rather than “In the last section modifying “see”).

The interpreter supports TAB completion; that is, pressing TAB will display all available symbols.
	Semicolon to indicate introduction of second clause, rather than appositive.  Remove “of” for grammar.

Though, in the same way, now the value of it has become [1, 2, 3].
	“Also” doesn’t fit, since there are not two values bound at once.  Perhaps “accordingly” or “in the same way” is meant.

and program understanding; however, it can cause
	Semicolon to separate independent clauses.

Here we see that this module provides one type synonym and three symbols.  (If your result does not match, try reloading the module.)
	The previous exercise may have changed x and y so they don’t appear in the output list shown.

Changed to "Namespace elements of a module name directly correlate with directory structure; e.g., this module labs::Interpreter::Interpreter maps directly to the file at labs/Interpreter/Interpreter.md.  Thus in order for the module to be found (essentially, finding the base directory for that path), either"
	This is an attempt to add one logic step between the description of path and file names associated with module names, on the one hand, and the “thus” clause that follows, which lists two options to make sure the module is found, on the other hand.  As it stood, I think I would not readily see that the fact “module name=path and file name” (essentially) implies that to find the module, the interpreter needs to be opened in a particular directory, or the CRYPTOLPATH environment variable must contain the base directory of the module.  For those of us who don’t automatically think, “As usual, pathnames referenced in code usually will cause the software to search for the beginning of that path in the current directory or in a base directory listed in an environment variable,” I think this phrase may be helpful.

Changed to "When you type `:e`, Cryptol will open the current file or module in a text editor, and will then reload the file into the interpreter when the editor is closed."
	Clarifying the two uses of the word “load” by replacing one.