### PR TITLE
Clarify-Basics

### DIFF
--- a/labs/Language/Basics.md
+++ b/labs/Language/Basics.md
@@ -476,7 +476,7 @@ middle of sequences, and so on. Please don't take these exercises to
 be considered *good* Cryptol. They were crafted to challenge you,
 something you should **never** do to someone who wants to use the
 specifications you write. Always strive to make elegant
-specifications. There is no need to optimize. Also, don't
+specifications. There is no need to optimize for performance. Also, don't
 write a spec "just to get it done" -- making something that loads and
 runs isn't good enough. Aim for creating specifications that *look*
 like the mathematics you're specifying. < rant over >

--- a/labs/Language/Basics.md
+++ b/labs/Language/Basics.md
@@ -404,7 +404,7 @@ previous `varType0` variable:
 varType0 = False : [10]
 ```
 
-When you reload this file in the interpreter, you would see the
+When you reload this file in the interpreter, you will see the
 following error:
 
 ```Xcryptol session

--- a/labs/Language/Basics.md
+++ b/labs/Language/Basics.md
@@ -476,7 +476,7 @@ middle of sequences, and so on. Please don't take these exercises to
 be considered *good* Cryptol. They were crafted to challenge you,
 something you should **never** do to someone who wants to use the
 specifications you write. Always strive to make elegant
-specifications. There is no need to optimize, and on the other hand, certainly don't
+specifications. There is no need to optimize. Also, don't
 write a spec "just to get it done" -- making something that loads and
 runs isn't good enough. Aim for creating specifications that *look*
 like the mathematics you're specifying. < rant over >

--- a/labs/Language/Basics.md
+++ b/labs/Language/Basics.md
@@ -27,10 +27,10 @@ Specifically, you'll also gain experience with
   * the `:check`, `:prove`, and `:sat` commands, 
   * pattern matching,
   * demoting types variables to value variables,
-  * `/\`, `\/`, `==>` -- single bit logical operations,
+  * `/\`, `\/`, `==>` -- logical operations for single bits,
   * `~`, `&&`, `||`, `^` -- logical operations for sequences,
   * `==`, `!=` -- structural comparison,
-  * `==`, `>=`, `>`, `<=`, `<` -- nonnegative word comparisons,
+  * `==`, `>=`, `>`, `<=`, `<` -- nonnegative-word comparisons,
   * `+`, `-`, `*`, `/`, `%`, `**` -- word-wise modular arithmetic,
   * `>>`, `<<`, `>>>`, `<<<` -- shifts and rotates,
   * `#` -- concatenation,
@@ -86,7 +86,7 @@ than with conventional languages. That's 'cause it's been tuned for
 such! To throw out the buzzwords:
   * Cryptol is a [domain-specific
     language](https://en.wikipedia.org/wiki/Domain-specific_language). Not
-    only does it have things to support its application domain, but also it elides
+    only does it have features to support its application domain, but also it elides
     a lot of junk that makes programming and analyzing the programs
     difficult.
   * Cryptol has been designed with automated reasoning about code
@@ -97,7 +97,7 @@ such! To throw out the buzzwords:
 In some ways this requires a new mind-set:
   * Write properties about your functions.
   * `:check` them.
-  * Invest in `:prove` when your function's definition has settled down.
+  * Try to `:prove` them when your function's definition has settled down.
 
 Enjoy getting addicted to this level of assurance!
 
@@ -112,7 +112,7 @@ material. Also consider keeping the [official Cryptol
 manual](https://github.com/GaloisInc/cryptol/blob/master/docs/ProgrammingCryptol.pdf)
 close at hand.
 
-For examples in this lab, the warning messages about specifying bit
+For examples in this lab, as they are displayed here, the warning messages about specifying bit
 sizes of numbers have been turned off. This is **not** something you
 should do when you're new at Cryptol; it's only done here for
 teaching purposes.
@@ -150,7 +150,7 @@ base 10.
 ## Modules
 
 This file is a Cryptol module. The first interpreted line of every Cryptol module
-must be `module Path::...Path::ModuleName where`. The `Path` component
+must be `module Path::...Path::ModuleName where`. The `Path::...Path` component
 is the system path from the root of whatever set of modules you're
 creating or working from. The `ModuleName` component is the basename
 of this file. For instance, this module is `labs::Language::Basics`
@@ -173,7 +173,7 @@ can qualify the module import using the `as` clause.
 import labs::Overview::Overview as OVLab
 ```
 
-When the Cryptol interpreter loads this lab, it gains access to all
+When the Cryptol interpreter loads the current lab (Basics), it gains access to all
 public definitions in the Overview lab.
 
 To keep a definition private, meaning it won't be imported by other
@@ -238,7 +238,7 @@ The most common of these are `module`, `import`, `private`, and `property`.
   * `/*` ... `*/` comments a block of code
 
 There is also a [docstring](https://en.wikipedia.org/wiki/Docstring)
-comment facility:
+comment facility (`/**` ... `*/` preceding a definition):
 
 ```cryptol
 /**
@@ -361,17 +361,17 @@ Other data types include:
     True
 ```
 
-  * Integers modulo _n_: Types of the form `[n]` already provide
+  * Integers modulo _n_: Each type of the form `[n]`, described above, provides a 
     [least residue
-    systems](https://en.wikipedia.org/wiki/Modular_arithmetic#Residue_systems)
+    system](https://en.wikipedia.org/wiki/Modular_arithmetic#Residue_systems)
     for [integers modulo
     2<sup>n</sup>](https://en.wikipedia.org/wiki/Modular_arithmetic#Integers_modulo_n).
-    Types of the form `Z n` provide that for any positive _n_. E.g.,
+    Types of the form `Z n` provide a least residue system for any positive _n_. E.g.,
     `4 + 4 : Z 7` evaluates to `1`.
 
 Though Cryptol supports a slew of different data types, most are not
 needed to be successful in this course. Specifically, this course
-makes heavy use sequences, with the occasional tuple and `Integer`
+makes heavy use of sequences, with the occasional tuple and `Integer`
 thrown in.
 
 **EXERCISE**: The Cryptol interpreter command `:type` (or `:t` for
@@ -404,7 +404,7 @@ previous `varType0` variable:
 varType0 = False : [10]
 ```
 
-When you reload this file in the interpreter, you will see the
+When you reload this file in the interpreter, you would see the
 following error:
 
 ```Xcryptol session
@@ -431,10 +431,10 @@ labs::Language::Basics> :t 5
 ```
 
 That letter `a` inside curly braces is a type variable. When you see a
-number (or a function) with a type variable (here, `a`), it means
+number (or a function) whose type is stated using a type variable (here, `a`), it means
 there is some freedom in the type of the value variable (here,
 `5`). For the next set of exercises, you'll be asked to type some
-variables monomorphically, that is, you shouldn't need any curly
+variables monomorphically; that is, you shouldn't need any curly
 braces or `=>` symbols when you specify the types. That's all stuff
 that's covered later in this section.
 
@@ -476,7 +476,7 @@ middle of sequences, and so on. Please don't take these exercises to
 be considered *good* Cryptol. They were crafted to challenge you,
 something you should **never** do to someone who wants to use the
 specifications you write. Always strive to make elegant
-specifications. There is no reason to optimize, and certainly don't
+specifications. There is no need to optimize, and on the other hand, certainly don't
 write a spec "just to get it done" -- making something that loads and
 runs isn't good enough. Aim for creating specifications that *look*
 like the mathematics you're specifying. < rant over >
@@ -485,7 +485,7 @@ like the mathematics you're specifying. < rant over >
 
 What would a programming language be without the ability to write
 functions? Since Cryptol is a pure functional language, functions are
-stateless (side-effect free) definitions that map inputs to an output.
+stateless (side-effect free) definitions that map each (valid) input to an output.
 
 Here is an example of a function called `add` that takes two arguments
 `x` and `y` and adds them together.
@@ -500,9 +500,9 @@ As it stands, this function works with many different types of `x` and
 sequences. Since this function accepts many different types of
 arguments, it's called
 [polymorphic](https://en.wikipedia.org/wiki/Polymorphism_(computer_science)):
-> the provision of a single interface to entities of different types.
+> provi[ding] a single interface to entities of different types.
 
-Often times, cryptographic functions are written to only work with
+Oftentimes, cryptographic functions are written to only work with
 specified types (such as having a 256-bit key), and we want to capture
 that information in our specifications. Hence, Cryptol functions can
 be typed, much the same way as typing variables (in the previous
@@ -567,11 +567,11 @@ labs::Language::Basics> uncurry add (20, 28)
 Hopefull you can see that these two styles are equivalent at some
 level. Curried functions are preferred as they afford [partial
 application](https://en.wikipedia.org/wiki/Partial_application), but
-the latter can be useful for explicating the correspondence to
+uncurried can be useful for explicating the correspondence to
 functions from other languages or documents.
 
   * If it helps you, mentally read curried functions like this: input
-    argument types are all prior to the last arrow and the result type
+    argument types are all prior to the last arrow, and the result type
     follows the last arrow. Pictorially: `in -> in -> ... -> in ->
     out`.
   * Partial application lets one form a new function from an old one
@@ -590,10 +590,10 @@ labs::Language::Basics> increment 10
 ```
 
    `add 1` takes a 32-bit bitvector and returns a 32-bit
-    bitvector. When it is applied to a 32-bit bitvector it adds one to
+    bitvector. When it is applied to a 32-bit bitvector, it adds one to
     that bitvector. Other examples to illustrate partial application:
   * `addUncurried` is really a function of one argument. It happens 
-  that the argument is a tuple which makes 
+  that the argument is a tuple, which makes 
   `addUncurried (28, 20)` look just like a
   two argument function in many languages.
 
@@ -622,7 +622,7 @@ funType7 x = (x, x, [ [[False, True], x], [x, x], [x, x] ])
 
 funType8 = funType2 10
 
-funType9 = False  //Is this a function with no arguments, or a variable? Hmmmm...is there a difference? Nope!
+funType9 = False  //Is this a function with no arguments, or a value? Hmmmm...is there a difference? Nope!
 ```
 
 Now that you have some experience *viewing* function types, you're
@@ -1081,7 +1081,8 @@ labs::Language::Basics> :s base=16
 ### Demoting Types to Values
 
 Because type variables and value variables are different classes of
-variables, they cannot interact directly. If we think of these two
+variables, they cannot interact directly (for example, we cannot write
+an expression equating the two). If we think of these two
 classes being in a hierarchy, type variables would be above value
 variables. With this hierarchy in mind, Cryptol does allow type variables
 to be **demoted** to value variables, but value variables cannot be
@@ -1092,8 +1093,8 @@ possible.
 notPossible size = 0 : [size]
 ```
 
-We cannot go from a value variable (`size`) up to a type
-variable. However, we can go down by using the backtick `` ` ``
+We cannot go from a value variable (`size` on the left) up to a type
+variable (`size` on the right). However, we can go down by using the backtick `` ` ``
 character. For example:
 
 ```cryptol
@@ -1104,15 +1105,15 @@ appendSize :
 appendSize input = input # [`size]
 ```
 
-Here we concatenate the size of a sequence onto the end. To read the
+Here we concatenate the size of a sequence onto the end of that sequence. To read the
 function definition more verbatim: 
 >`appendSize` takes an input named
 `input` that is a sequence of `size` number of 32-bit elements and
-outputs a sequence of `size+1` 32-bit elements where the first `size`
+outputs a sequence of `size+1` 32-bit elements, where the first `size`
 elements are `input` and the last element is the size of the input
 sequence. 
 
-When type variables are demoted into value variables, they
+When type variables are demoted to value variables, they
 must take on a type. Cryptol usually infers the correct type, and in
 this case `` `size `` becomes a 32-bit value. It is because of this
 that the function has `32 >= width size` as a type constraint. If
@@ -1204,7 +1205,7 @@ that allows you to create local definitions in functions. There's
 really not too much to this, but you'll use it in almost every Cryptol
 function you'll ever write, so consider it important.
 
-Here we describe what a function looks like in Cryptol. (For the numbered identifiers, we limit ourselves to two or three examples, but in reality there can be any number.)
+Here we describe what a function looks like in Cryptol. (For the numbered identifiers here, we limit ourselves to two or three examples, but in reality there can be any number.)
 
 ```comment
 functionName :
@@ -1239,7 +1240,7 @@ Function type specification:
 ||||||
 |-|-|-|-|-|
 | `inputType0` | `->` | `inputType1` | `->` | `outputType`
-| that takes `inputType0` | and | `inputType1` | and returns | `outputType`
+| that takes `inputType0` | and | `inputType1` | and returns | `outputType`.
 
 Function definition:
 |||||
@@ -1250,7 +1251,7 @@ Function definition:
 ||
 |-|
 | `output` |
-| the value of `output`
+| the value of `output`,
 
 ||
 |-|
@@ -1260,17 +1261,17 @@ Function definition:
 ||
 |-|
 | `localVariable0` `=` `expression0`
-| `localVariable0` is assigned the value of `expression0`
+| `localVariable0` is assigned the value of `expression0`,
 
 ||
 |-|
 | `localVariable1` `=` `expression1`
-| `localVariable1` is assigned the value of `expression1`
+| `localVariable1` is assigned the value of `expression1`,
 
 ||
 |-|
 | `output` `=` `expression2`
-| `output` is assigned the value of `expression0`
+| and `output` is assigned the value of `expression0`.
 
 Here's an example that demonstrates the use of a `where` clause:
 
@@ -1289,7 +1290,7 @@ And the breakdown:
 |||||||||||||
 |-|-|-|-|-|-|-|-|-|-|-|-|
 | `addMult` | `:` | `{n}` | `(fin n)` | `=>` | `[n]` | `->` | `[n]` | `->` | `[n]` | `->` | `[n]`
-| The function `addmult` | has a type | with type variable `n` | and the constraint that `n` is finite | applied to the type definition | that takes an `n`-bit vector | and&nbsp;  | an `n`-bit vector | and&nbsp; | an `n`-bit vector | and returns | an `n`-bit vector
+| The function `addmult` | has a type | with type variable `n` | and the constraint that `n` is finite | applied to the type definition | that takes an `n`-bit vector | and&nbsp;  | an `n`-bit vector | and&nbsp; | an `n`-bit vector | and returns | an `n`-bit vector.
 
 ## Properties
 
@@ -1351,7 +1352,7 @@ a simple way to create a function
 without giving it a name. We'd read the above as, "Cryptol, find an
 assignment to `x` such that `increment x < x`." And since the type of
 `increment` forces `x` to be a 32-bit bitvector, `increment
-0xffffffff` overflows to zero.
+0xffffffff` overflows to zero, yielding the solution 0xffffffff.
 
 ## Operators
 
@@ -1373,7 +1374,7 @@ the zero-based index of the element to select from the sequence.
 Many languages differentiate signed and unsigned numbers at the type
 level (e.g. C's `uint32` and `int32`). Cryptol has separate operators
 for signed operations which are indicated by a suffixed `$`. Most of
-the time you don't need them as cryptography tends to use nonnegative
+the time you don't need them, as cryptography tends to use nonnegative
 numbers. In case you do, Cryptol also has `carry`, `scarry`, and
 `sborrow` operators for computing overflow and underflow of addition
 and subtraction.
@@ -1426,7 +1427,7 @@ multiplication. However, in Cryptol `1 / 3 == 0 :
 respectively, in
 [Euclidean division](https://en.wikipedia.org/wiki/Euclidean_division).
 
-### Bitwise logical: negation `~`, conjunction `&&`, disjunction `||` and exclusive or `^`
+### Bitwise logical: negation `~`, conjunction `&&`, disjunction `||` and exclusive-or `^`
 
 ```Xcryptol session
 labs::Language::Basics> :s base=2
@@ -1607,7 +1608,7 @@ by the name of the primitive.
   (0x00, 0x0)
 ```
 
-Here we produce an ordered pair of a 0 octet and a 0 nibble.
+Here we have produced an ordered pair of a 0 octet and a 0 nibble.
   * `~0` and `~zero` produce all `True` bits correspondingly.
 
 
@@ -1631,11 +1632,11 @@ labs::Language::Basics> reverse [0, 0, 1] : [3]Integer
 Of course, the sizes of lists have to be big enough for 
 the requested operation. Also, notice that
 `head` (which is equivalent to `@0`) and `last` (which is equivalent to
-`!0`) return an element while the others return lists.
+`!0`) return an element, while the others return lists.
 
 Often in a Cryptol program, the context will determine the shapes of
 sequences, so that the type annotations (`: [3][8]` and `: [3]Integer`
-above) will be unnecessary.
+above) will then be unnecessary.
 
 ### List shape manipulation: `split`, `groupBy`, `join`, `transpose`
 
@@ -1658,7 +1659,7 @@ Cryptol supports a few common idioms in functional programming. This
 section briefly touches upon five of these.
 
 The `sum` operator takes a sequence of elements and accumulates them.
-Similar to other operators, `sum` acts element-wise and as such
+Similar to other operators, `sum` acts element-wise, and as such
 accepts sequences of any type that arithmetic can be applied to.
 
 ```Xcryptol session
@@ -1708,7 +1709,7 @@ Showing a specific instance of polymorphic result:
 
 The `foldl` operator transitions an initial state given a 'next state'
 function and a list of elements to act on at each transition. `scanl`
-works just like `foldl`, but returns the state at each transition,
+works just like `foldl`, but returns the state at each transition (hence, a sequence of states),
 rather than the final state. In fact, `foldl == last scanl`.
 
 ```Xcryptol session
@@ -1837,8 +1838,8 @@ Star Trek's (T.O.S.) warp factor light speed multipliers!
 
 ||||||||
 |-|-|-|-|-|-|-|
-| `[` | `n^^3` | `\|` | `n` | `<-` | `[0..10]` | `]`
-| Generate the sequence | with elements of the form `n^^3` | where | `n` | draws from | the sequence `0` through `10`
+| `[` | `n^^3` | `|` | `n` | `<-` | `[0..10]` | `]`
+| Generate the sequence | with elements of the form `n^^3` | where | `n` | draws from | the sequence `0` through `10`.
 ||||||||
 
 We refer to the right-hand side (`n <- [0..10]`)
@@ -1950,8 +1951,8 @@ Here's an English-language breakdown of the first self-referential sequence comp
 
 ||||||||||||
 |-|-|-|-|-|-|-|-|-|-|-|
-| `roundKeys` | `=` | `[key]` | `#` | `[` | `roundKey <<< 1` | `\|` | `roundKey` | `<-` | `roundKeys` | `]`
-| The sequence `roundKeys` | is defined as | an initial `key` | followed by | the sequence | with elements of the form `roundKey <<< 1` | where | `roundKey` | draws from | the generated sequence `roundKeys` itself
+| `roundKeys` | `=` | `[key]` | `#` | `[` | `roundKey <<< 1` | `|` | `roundKey` | `<-` | `roundKeys` | `]`
+| The sequence `roundKeys` | is defined as | an initial `key` | followed by | the sequence | with elements of the form `roundKey <<< 1` | where | `roundKey` | draws from | the generated sequence `roundKeys` itself.
 ||||||||||||
 
 Many block ciphers are just variations of the above theme. 


### PR DESCRIPTION
Clarify Basics lab, version 3 (my version 3, just one pull request):  Fixed two typos from first commit.
Working from master branch of Basics.md.  8 Sep 2020 3:50 p.m.

(Format here:  Issue or suggested text listed first, then [indented] why the change is suggested.)
-----------------------------------------------------------------------------------------
logical operations for single bits
	For parallel style with next bullet, clarity.

nonnegative-word comparisons
	Although this hyphen is considered optional these days, the sentence reads more easily with it in, because it clarifies we are doing comparisons of nonnegative words, rather than nonnegative comparisons of words, whatever that would be.

Not only does it have features to support
	“Things” is too vague.

Try to `:prove` them when
	I don’t know what “Invest in `:prove`” would mean.

For examples in this lab, as they are displayed here, the warning messages about specifying bit
sizes of numbers have been turned off.
	Self-explanatory.

The `Path::...Path` component is the system path
	Referring to it as the `Path` component is incomplete.

When the Cryptol interpreter loads The current lab (Basics), it gains access to all
	For clarity:  “this lab” could refer to the Overview lab just mentioned, or to the current lab, so this change makes it explicit.

There is also a [docstring](https://en.wikipedia.org/wiki/Docstring) comment facility (`/**` ... `*/` preceding a definition)
	The syntax should be stated before the example is shown, or else the example could be interpreted incorrectly. (E.g., is the asterisk need on each line as in the example? Or not? Or is it sufficient to simple put the comment immediately before the definition? Or not?) I know this from experience while taking the class.

Each type of the form `[n]`, described above, provides a [least residue system]
Types of the form `Z n` provide a least residue system
	To clarify that a single [n] corresponds to a single least residue system mod 2^^n, and that the n in `Z n` is not the n in the exponent of 2^^n.

use of sequences
	Typo.

you would see
	The sentence jumps back and forth between hypothetical (subjunctive?) and future; this suggestion is to maybe reduce that a little.

When you see a number (or a function) whose type is stated using a type variable
	“With” was too vague.

There is no need to optimize, and on the other hand, certainly don't write a spec "just to get it done"
	“Need” rather than “reason,” because you can always find someone with a reason, but that doesn’t make it a need.  Inserted “on the other hand” to clarify that the second clause is not a continuation of the rationale stated in the first clause.

that map each (valid) input to an output
	Saying plural input and singular output sounds like the function maps everything to one point.

provi[ding] a single interface to entities of different types
	The phrase is shown as a quotation (from Wikipedia), so it should render the quotation accurately.  It should also put the term (“polymorphic”) and the definition (“provi[ding]”) in parallel form (here both adjectives; was “polymorphic” and “the provision of”, which are adjective and noun, respectively).

but uncurried can be useful
	Was not clear which one “the latter” referred to.

//Is this a function with no arguments, or a value?
	Erroneously said “variable”.

- A couple changes to clarify type variables and value variables and their values:

1.  “Because type variables and value variables are different classes of variables, they cannot interact directly (for example, we cannot write an expression equating the two).”
	Clarifying the word “interact.”

2.  “We cannot go from a value variable (`size` on the left) up to a type variable (`size` on the right).”
	Just saying which is which.

- A few punctuation items (not listed here).

And since the type of `increment` forces `x` to be a 32-bit bitvector, `increment 0xffffffff` overflows to zero, yielding the solution 0xffffffff.
	I think the point was to say the solution is found this way, so that should be said.

- The Star Trek example of how to read a sequence comprehension showed a pipe symbol (‘|’) as `\|`, but I think it is just supposed to be `|`.  The same for the next how-to-read example (roundKey).