### PR TITLE
Basics-pattern-matching-suggested-clarification

### DIFF
--- a/labs/Language/Basics.md
+++ b/labs/Language/Basics.md
@@ -759,18 +759,18 @@ side. Again, `_` acts as a kind of hole (when it's by itself,
 not when it's part of an identifier, of course). For example:
 
 ```Xcryptol session
-labs::Language::Basics> let (a, b) = (4, 5)
-labs::Language::Basics> a
+labs::Language::Basics> let (fst, snd) = (4, 5)
+labs::Language::Basics> fst
 4
-labs::Language::Basics> b
+labs::Language::Basics> snd
 5
-labs::Language::Basics> let c = (0xa, 0xb)
-labs::Language::Basics> c
+labs::Language::Basics> let r = (0xa, 0xb)
+labs::Language::Basics> r
 (0xa, 0xb)
-labs::Language::Basics> let (a, b) = c
-labs::Language::Basics> a
+labs::Language::Basics> let (fst, snd) = r
+labs::Language::Basics> fst
 0xa
-labs::Language::Basics> b
+labs::Language::Basics> snd
 0xb
 labs::Language::Basics> let [ (a, b, _), (_, _, c), _ ] = [ (1, 2, 3), (4, 5, 6), (7, 8, 9) ] : [3]([4], [4], [4])
 labs::Language::Basics> a

--- a/labs/Language/Basics.md
+++ b/labs/Language/Basics.md
@@ -755,13 +755,19 @@ statements aren't restricted to just single variables. This
 flexibility comes from Cryptol's powerful **pattern matching**
 capabilities. Cryptol allows you to make assignments by writing
 patterns based on the type (*shape*) of the value on the right-hand
-side. Again, `_` acts a kind of hole. For example:
+side. Again, `_` acts as a kind of hole (when it's by itself,
+not when it's part of an identifier, of course). For example:
 
 ```Xcryptol session
-labs::Language::Basics> let ab = (0xa, 0xb)
-labs::Language::Basics> ab
+labs::Language::Basics> let (a, b) = (4, 5)
+labs::Language::Basics> a
+4
+labs::Language::Basics> b
+5
+labs::Language::Basics> let c = (0xa, 0xb)
+labs::Language::Basics> c
 (0xa, 0xb)
-labs::Language::Basics> let (a, b) = ab
+labs::Language::Basics> let (a, b) = c
 labs::Language::Basics> a
 0xa
 labs::Language::Basics> b


### PR DESCRIPTION
Basics.md, suggestions for pattern matching examples.
Working from master branch.  8 Sep 2020 6:36 p.m.

The pattern-matching explanation is not as transparent as it could be.  I think the person who put it together was trying to make the names meaningful by calling `(a, b)` by the identifier `ab` and giving it the value `(0xa, 0xb)`, so that the assignment `let (a, b) = ab` would give `a` the value `0xa` and b the value `0xb`.

I, however, had to stare at the variable assignments and explicitly think through the distinctions, “Here `a` and `b` are part of a single identifier; they are not being multiplied; here they are hex digits; and here they are separate identifiers.”  Notice that this struggle is really a side issue to the question of what pattern matching does.

I think it would be better, then, to start off with a completely straightforward example, using literal values that don’t look like variables, and not reusing characters in a way that might introduce confusion (confusion unrelated to the concept being taught, that it).  Hence the suggestion and the extra verbiage I offer here.