### PR TITLE
Basics--note to recover overwritten code snippets

### DIFF
--- a/labs/Language/Basics.md
+++ b/labs/Language/Basics.md
@@ -1056,6 +1056,13 @@ the curly braces, so you don't need to provide the `name=` part.
 `repeat` function we wrote above, though there are solutions that
 don't require it.
 
+(Note:  Many times in this course you will be asked to do a coding exercise in
+which your assignment is to alter a snippet of code.  If when doing so you
+find you need to start over, but you have saved over the original code snippet
+and do not know what the original looked like, you may find the original by
+locating the current module in the course repository on
+[GitHub](https://github.com/weaversa/cryptol-course).)
+
 ```cryptol
 // Uncomment and fill in
 //zeroPrepend : {} (?) => ? -> ?


### PR DESCRIPTION
Basics.md, just telling students what to do if they save over a code snippet and want to recover it.

Working from master branch.  9 Sep 2020 3:20 p.m.

The suggested change is self-explanatory, just a note to students that many would find obvious (so perhaps unnecessary)--but not me when I took the class, for some reason; I always copied the snippet in place so I'd have a backup.  Also, for students unfamiliar with GitHub, it may serve as an encouragement to browse there a little.