### PR TITLE
Basics--Simplify foldl, scanl explanations

### DIFF
--- a/labs/Language/Basics.md
+++ b/labs/Language/Basics.md
@@ -1706,35 +1706,35 @@ Showing a specific instance of polymorphic result:
 [0, 3, 6, 9, 12, ...]
 ```
 
-The `foldl` operator transitions an initial state given a 'next state'
-function and a list of elements to act on at each transition. `scanl`
-works just like `foldl`, but returns the state at each transition,
-rather than the final state. In fact, `foldl == last scanl`.
+The `scanl` operator transitions an initial state given a 'next state'
+function and a sequence of elements to act on at each transition.  `scanl` 
+returns the sequence of initial and transitioned states. `foldl`, which 
+you may find more useful, works just like `scanl`, but returns only the final 
+state after all transitions. In fact, `foldl == last scanl`.
 
 ```Xcryptol session
-labs::Language::Basics> let step state c = if c == True then state+1 else state-1
-labs::Language::Basics> foldl step 0 [True, True, False, False, True]
-Showing a specific instance of polymorphic result:
-  * Using 'Integer' for 1st type argument of '<interactive>::step'
-1
-labs::Language::Basics> scanl step 0 [True, True, False, False, True]
-Showing a specific instance of polymorphic result:
-  * Using 'Integer' for 1st type argument of '<interactive>::step'
-[0, 1, 2, 1, 0, 1]
-labs::Language::Basics> foldl (+) 0 [1, 2, 3, 4, 5]
-Showing a specific instance of polymorphic result:
-  * Using 'Integer' for type of sequence member
-15
 labs::Language::Basics> scanl (+) 0 [1, 2, 3, 4, 5]
 Showing a specific instance of polymorphic result:
   * Using 'Integer' for type of sequence member
 [0, 1, 3, 6, 10, 15]
+labs::Language::Basics> foldl (+) 0 [1, 2, 3, 4, 5]
+Showing a specific instance of polymorphic result:
+  * Using 'Integer' for type of sequence member
+15
+labs::Language::Basics> let step state c = if c == True then state+1 else state-1
+labs::Language::Basics> scanl step 0 [True, True, False, False, True]
+Showing a specific instance of polymorphic result:
+  * Using 'Integer' for 1st type argument of '<interactive>::step'
+[0, 1, 2, 1, 0, 1]
+labs::Language::Basics> foldl step 0 [True, True, False, False, True]
+Showing a specific instance of polymorphic result:
+  * Using 'Integer' for 1st type argument of '<interactive>::step'
+1
+labs::Language::Basics> scanl (<<) 1 [1, 2, 3, 4] : [5][12]
+[0b000000000001, 0b000000000010, 0b000000001000, 0b000001000000, 0b010000000000]
 labs::Language::Basics> :s base=2
 labs::Language::Basics> foldl (<<) 1 [1, 2, 3, 4] : [12]
 0b010000000000
-labs::Language::Basics> scanl (<<) 1 [1, 2, 3, 4] : [5][12]
-[0b000000000001, 0b000000000010, 0b000000001000, 0b000001000000,
- 0b010000000000]
 ```
 
 In most Cryptol programs, the context will enforce the size of things,


### PR DESCRIPTION
Basics.md, clearer presentation of foldl and scanl.
Working from master branch.  9 Sep 2020 4:20 p.m.

The explanation of `foldl` and `scanl` could be made simpler.

First, the easiest example should be shown first, which is the addition example (`(+)`), because everyone is really familiar with addition.  If you see the addition example, you can picture it in your head, whereas the others are not as easy to visualize.  Granted, addition does not give as much of a feel for how the one value is being transitioned, and the input sequence of values is being used to transition it, but that can be learned from the harder examples.

Second, even though it seems we are more interested in learning `foldl` than `scanl`, the better order to learn them is to start with scanl.  If you do `foldl` before `scanl`, then for `foldl` you have to imagine stepping through the sequence and getting the final value, and then for `scanl` you have to retrace your steps to imagine outputting the whole sequence.  But if you do `scanl` before `foldl`, then you get the whole sequence with `scanl`, and `foldl` requires no more work--just grab the last value.

Also, by the way, the existing explanation defines `foldl` partway, without saying what the output is at first, and then defines `scanl`, and while defining `scanl` finally says what the output of `foldl` is.  So that should be fixed at the same time.

Hence the suggested changes.