### PR TITLE
Corrects broken links from `Langauge` to `Language`

### DIFF
--- a/labs/CRC/CRC.md
+++ b/labs/CRC/CRC.md
@@ -346,5 +346,5 @@ https://github.com/weaversa/cryptol-course/issues
 # From here, you can go somewhere!
 
 Up: [Course README](/README.md)
-Previous: [Language Basics](/labs/Langauge/Basics.md)
+Previous: [Language Basics](/labs/Language/Basics.md)
 Next: [Salsa20](/labs/Salsa20/Salsa20.md)

--- a/labs/CRC/CRCAnswers.md
+++ b/labs/CRC/CRCAnswers.md
@@ -346,5 +346,5 @@ https://github.com/weaversa/cryptol-course/issues
 # From here, you can go somewhere!
 
 Up: [Course README](/README.md)
-Previous: [Language Basics](/labs/Langauge/Basics.md)
+Previous: [Language Basics](/labs/Language/Basics.md)
 Next: [Salsa20](/labs/Salsa20/Salsa20.md)

--- a/labs/Demos/Cryptol/Caesar.md
+++ b/labs/Demos/Cryptol/Caesar.md
@@ -342,5 +342,5 @@ https://github.com/weaversa/cryptol-course/issues
 # From here, you can go somewhere!
 
 Up: [Cryptol Demos](/Demos/Cryptol/Demos.md)
-Previous: [Language Basics](/labs/Langauge/Basics.md)
+Previous: [Language Basics](/labs/Language/Basics.md)
 Next: [Salsa20](/labs/Salsa20/Salsa20.md)

--- a/labs/Demos/Cryptol/Demos.md
+++ b/labs/Demos/Cryptol/Demos.md
@@ -18,5 +18,5 @@ https://github.com/weaversa/cryptol-course/issues
 # From here, you can go somewhere!
 
 Up: [Course README](/README.md)
-Previous: [Language Basics](/labs/Langauge/Basics.md)
+Previous: [Language Basics](/labs/Language/Basics.md)
 Next: [Salsa20](/labs/Salsa20/Salsa20.md)

--- a/labs/Demos/Cryptol/NQueens.md
+++ b/labs/Demos/Cryptol/NQueens.md
@@ -238,5 +238,5 @@ https://github.com/weaversa/cryptol-course/issues
 # From here, you can go somewhere!
 
 Up: [Cryptol Demos](/Demos/Cryptol/Demos.md)
-Previous: [Language Basics](/labs/Langauge/Basics.md)
+Previous: [Language Basics](/labs/Language/Basics.md)
 Next: [Salsa20](/labs/Salsa20/Salsa20.md)

--- a/labs/Demos/Cryptol/OneTimePad.md
+++ b/labs/Demos/Cryptol/OneTimePad.md
@@ -326,5 +326,5 @@ https://github.com/weaversa/cryptol-course/issues
 # From here, you can go somewhere!
 
 Up: [Cryptol Demos](/Demos/Cryptol/Demos.md)
-Previous: [Language Basics](/labs/Langauge/Basics.md)
+Previous: [Language Basics](/labs/Language/Basics.md)
 Next: [Salsa20](/labs/Salsa20/Salsa20.md)

--- a/labs/Demos/Cryptol/Sudoku.md
+++ b/labs/Demos/Cryptol/Sudoku.md
@@ -588,5 +588,5 @@ https://github.com/weaversa/cryptol-course/issues
 # From here, you can go somewhere!
 
 Up: [Cryptol Demos](/Demos/Cryptol/Demos.md)
-Previous: [Language Basics](/labs/Langauge/Basics.md)
+Previous: [Language Basics](/labs/Language/Basics.md)
 Next: [Salsa20](/labs/Salsa20/Salsa20.md)

--- a/labs/Demos/SAW/ArithmeticVerifications/ArithmeticVerifications.md
+++ b/labs/Demos/SAW/ArithmeticVerifications/ArithmeticVerifications.md
@@ -114,5 +114,5 @@ https://github.com/weaversa/cryptol-course/issues
 # From here, you can go somewhere!
 
 Up: [Course README](/README.md)
-Previous: [Language Basics](/labs/Langauge/Basics.md)
+Previous: [Language Basics](/labs/Language/Basics.md)
 Next: [Salsa20](/labs/Salsa20/Salsa20.md)

--- a/labs/Demos/SAW/Bittwiddling/Bittwiddling.md
+++ b/labs/Demos/SAW/Bittwiddling/Bittwiddling.md
@@ -185,5 +185,5 @@ https://github.com/weaversa/cryptol-course/issues
 # From here, you can go somewhere!
 
 Up: [Course README](/README.md)
-Previous: [Language Basics](/labs/Langauge/Basics.md)
+Previous: [Language Basics](/labs/Language/Basics.md)
 Next: [Salsa20](/labs/Salsa20/Salsa20.md)

--- a/labs/Demos/SAW/Bittwiddling/BittwiddlingAnswers.md
+++ b/labs/Demos/SAW/Bittwiddling/BittwiddlingAnswers.md
@@ -167,5 +167,5 @@ https://github.com/weaversa/cryptol-course/issues
 # From here, you can go somewhere!
 
 Up: [Course README](/README.md)
-Previous: [Language Basics](/labs/Langauge/Basics.md)
+Previous: [Language Basics](/labs/Language/Basics.md)
 Next: [Salsa20](/labs/Salsa20/Salsa20.md)

--- a/labs/Demos/SAW/Demos.md
+++ b/labs/Demos/SAW/Demos.md
@@ -28,5 +28,5 @@ https://github.com/weaversa/cryptol-course/issues
 # From here, you can go somewhere!
 
 Up: [Course README](/README.md)
-Previous: [Language Basics](/labs/Langauge/Basics.md)
+Previous: [Language Basics](/labs/Language/Basics.md)
 Next: [Salsa20](/labs/Salsa20/Salsa20.md)


### PR DESCRIPTION
"Breadcrumbs" are nice, but introduce another way for errors to creep in.  This is a common problem for site navigation.  We might consider adding a CI script to check for broken links, or (more ambitiously) to check for navigation consistent with the course graph, but for now I've just fixed the broken links associated with `Language Basics`.