### PR TITLE
Update Transposition Lab

### DIFF
--- a/labs/Transposition/CommonProperties.md
+++ b/labs/Transposition/CommonProperties.md
@@ -268,8 +268,8 @@ labs::Transposition::CommonProperties> :s prover=abc
 labs::Transposition::CommonProperties> 
 ```
 
-**EXERCISE**: Use ABC to prove that (DES.encrypt key) is equivalent 
-to (DES.encrypt (DESFixParity key)).  Do not mention `pt` in your 
+**EXERCISE**: Use ABC to prove that `DES.encrypt key` is equivalent 
+to `DES.encrypt (DESFixParity key)`.  Do not mention `pt` in your 
 proof command.
 
 ```Xcryptol session

--- a/labs/Transposition/CommonProperties.md
+++ b/labs/Transposition/CommonProperties.md
@@ -16,10 +16,8 @@ Before working through this lab, you'll need
 You'll also need experience with
   * loading modules and evaluating functions in the interpreter,
   * sequence and `Integer` types,
-  * the `:prove` and `:sat` commands,
   * manipulating sequences using `#`, `take`, `split`, and `join`,
   * writing functions and properties,
-  * lambda functions,
   * sequence comprehensions,
   * logical, comparison, and arithmetic operators,
   * lambda functions, and
@@ -206,7 +204,7 @@ collides f x x' =
 
 Cryptol went ahead and reserved infix operator `===` to denote that 
 functions map the same value to the same value, so `:prove f === f'` 
-is shorthand for `:prove \x -> f x == f' x`.  Functional equivalance 
+is shorthand for `:prove \x -> f x == f' x`.  Functional equivalence 
 must be pretty important!
 
 # DES Exercises, Redux
@@ -271,7 +269,7 @@ labs::Transposition::CommonProperties>
 ```
 
 **EXERCISE**: Use ABC to prove that (DES.encrypt key) is equivalent 
-to (DES.encrypt (DESFixParity)).  Do not mention `pt` in your 
+to (DES.encrypt (DESFixParity key)).  Do not mention `pt` in your 
 proof command.
 
 ```Xcryptol session

--- a/labs/Transposition/CommonPropertiesAnswers.md
+++ b/labs/Transposition/CommonPropertiesAnswers.md
@@ -16,10 +16,8 @@ Before working through this lab, you'll need
 You'll also need experience with
   * loading modules and evaluating functions in the interpreter,
   * sequence and `Integer` types,
-  * the `:prove` and `:sat` commands,
   * manipulating sequences using `#`, `take`, `split`, and `join`,
   * writing functions and properties,
-  * lambda functions,
   * sequence comprehensions,
   * logical, comparison, and arithmetic operators,
   * lambda functions, and
@@ -206,7 +204,7 @@ collides f x x' =
 
 Cryptol went ahead and reserved infix operator `===` to denote that 
 functions map the same value to the same value, so `:prove f === f'` 
-is shorthand for `:prove \x -> f x == f' x`.  Functional equivalance 
+is shorthand for `:prove \x -> f x == f' x`.  Functional equivalence 
 must be pretty important!
 
 # DES Exercises, Redux
@@ -291,7 +289,7 @@ Q.E.D.
 ```
 
 **EXERCISE**: Use ABC to prove that (DES.encrypt key) is equivalent 
-to (DES.encrypt (DESFixParity)).  Do not mention `pt` in your 
+to (DES.encrypt (DESFixParity key)).  Do not mention `pt` in your 
 proof command.
 
 ```Xcryptol session

--- a/labs/Transposition/CommonPropertiesAnswers.md
+++ b/labs/Transposition/CommonPropertiesAnswers.md
@@ -288,8 +288,8 @@ Q.E.D.
 (Total Elapsed Time: 0.497s, using "ABC")
 ```
 
-**EXERCISE**: Use ABC to prove that (DES.encrypt key) is equivalent 
-to (DES.encrypt (DESFixParity key)).  Do not mention `pt` in your 
+**EXERCISE**: Use ABC to prove that `DES.encrypt key` is equivalent 
+to `DES.encrypt (DESFixParity key)`.  Do not mention `pt` in your 
 proof command.
 
 ```Xcryptol session

--- a/labs/Transposition/RailFence.md
+++ b/labs/Transposition/RailFence.md
@@ -94,22 +94,30 @@ occurring in the first cycle.  Check your definition using
 `cycle_test`.  Here's a starter:
 
 ``cycle`{r=1} == [0]``
+<pre>
 0 ...
+</pre>
 
 ``cycle`{r=2} == [0,1]``
+<pre>
 0 0 ...
  1 1
+</pre>
 
 ``cycle`{r=3} == [0,1,3,2]``
+<pre>
 0   0   0   ...
  1 3 1 3 1 3
   2   2   2
+</pre>
 
 ``cycle`{r=4} == [0,1,5,2,4,3]``
+<pre>
 0     0     0     ...
  1   5 1   5 1   5
   2 4   2 4   2 4
    3     3     3
+</pre>
 
 (Hint: Your definition will most likely include logic distinguishing 
 the top, bottom, and middle rails.  You might wish to implement a 

--- a/labs/Transposition/RailFenceAnswers.md
+++ b/labs/Transposition/RailFenceAnswers.md
@@ -235,4 +235,4 @@ https://github.com/weaversa/cryptol-course/issues
 
 Up: [Course README](../../README.md)
 Previous: [Scytale: A classic easy-to-specify transposition cipher](ScytaleAnswers.md)
-Next: [Route: We've worked hard enough -- your turn!](RouteAnswers.md)
+Next: [Route: We've worked hard enough -- your turn!](Route.md)

--- a/labs/Transposition/RailFenceAnswers.md
+++ b/labs/Transposition/RailFenceAnswers.md
@@ -94,22 +94,30 @@ occurring in the first cycle.  Check your definition using
 `cycle_test`.  Here's a starter:
 
 ``cycle`{r=1} == [0]``
+<pre>
 0 ...
+</pre>
 
 ``cycle`{r=2} == [0,1]``
+<pre>
 0 0 ...
  1 1
+</pre>
 
 ``cycle`{r=3} == [0,1,3,2]``
+<pre>
 0   0   0   ...
  1 3 1 3 1 3
   2   2   2
+</pre>
 
 ``cycle`{r=4} == [0,1,5,2,4,3]``
+<pre>
 0     0     0     ...
  1   5 1   5 1   5
   2 4   2 4   2 4
    3     3     3
+</pre>
 
 (Hint: Your definition will most likely include logic distinguishing 
 the top, bottom, and middle rails.  You might wish to implement a 

--- a/labs/Transposition/Route.md
+++ b/labs/Transposition/Route.md
@@ -77,3 +77,4 @@ https://github.com/weaversa/cryptol-course/issues
 
 Up: [Course README](../../README.md)
 Previous: [Rail Fence: A basic transposition cipher for humans that's not-so-basic for Cryptol](RailFence.md)
+Next: [Capstone](../LoremIpsum/LoremIpsum.md)

--- a/labs/Transposition/Scytale.md
+++ b/labs/Transposition/Scytale.md
@@ -4,9 +4,8 @@ This module defines a classic transposition "cipher" that encrypts a
 message by wrapping it around a (virtual) [scytale](https://en.wikipedia.org/wiki/Scytale).  
 The cipher is defined in terms of the 
 `labs::Transposition::Transposition` library, which defines `encrypt` 
-and `decrypt` functions given a permutation mapping, which in this 
-case just returns ``reverse (take`{n} [0...])`` given a message of 
-length `n`.
+and `decrypt` functions given a permutation mapping reflecting 
+positions on a scytale.
 
 ## Prerequisites
 

--- a/labs/Transposition/ScytaleAnswers.md
+++ b/labs/Transposition/ScytaleAnswers.md
@@ -4,9 +4,8 @@ This module defines a classic transposition "cipher" that encrypts a
 message by wrapping it around a (virtual) [scytale](https://en.wikipedia.org/wiki/Scytale).  
 The cipher is defined in terms of the 
 `labs::Transposition::Transposition` library, which defines `encrypt` 
-and `decrypt` functions given a permutation mapping, which in this 
-case just returns ``reverse (take`{n} [0...])`` given a message of 
-length `n`.
+and `decrypt` functions given a permutation mapping reflecting 
+positions on a scytale.
 
 ## Prerequisites
 


### PR DESCRIPTION
Removed redundant prerequisites, corrected a spelling error, and corrected an error in the equivalence exercise in `CommonProperties.md`.