### PR TITLE
Default to using the Dockerhub image, rather than the Dockerfile.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
     "name": "Cryptol Course Dev",
     "image": "cryptolcourse/dev",
-    "dockerFile": "Dockerfile",
+    //"dockerFile": "Dockerfile",
     "runArgs": [],
 
     // Use 'settings' to set *default* container specific settings.json values on container create. 


### PR DESCRIPTION
Students should just use the uploaded Dockerhub image. Developers (or students when necessary) can uncomment the Dockerfile line if they want to make modifications. But Dockerhub should be the default