### PR TITLE
Added Matt's proof for ceilLog2's CLZ implementation

### DIFF
--- a/.github/workflows/python-saw.yml
+++ b/.github/workflows/python-saw.yml
@@ -65,3 +65,5 @@ jobs:
       - run: cd labs/SAW/proof && clang ../src/null.c -o ../src/null.bc -c -emit-llvm && python3 null.py
       # Run Game SAW Script
       - run: cd labs/SAW/Game/DLC && mkdir artifacts && clang -c -g -emit-llvm -o artifacts/Game.bc src/Game.c && python3 proof/Game.py
+      # Run ceilLog2 SAW Script
+      - run: cd labs/SAW/ceilLog2 && mkdir artifacts && clang -c -g -emit-llvm -o artifacts/ceilLog2.bc src/ceilLog2.c && python3 proof/ceilLog2.py

--- a/.github/workflows/python-saw.yml
+++ b/.github/workflows/python-saw.yml
@@ -58,13 +58,26 @@ jobs:
       # Start saw-remote-api server
       - run: start-saw-remote-api-read-only
       # Run final rotl SAW Script
-      - run: cd labs/SAW/proof && clang ../src/rotl3.c -o ../src/rotl.bc -c -emit-llvm && python3 rotl.py
+      - run: |
+          cd labs/SAW/proof
+          clang ../src/rotl3.c -o ../src/rotl.bc -c -emit-llvm
+          python3 rotl.py
       # Run addRow SAW Script
-      - run: cd labs/SAW/proof && clang ../src/addRow.c -o ../src/addRow.bc -c -emit-llvm && python3 addRow.py
+      - run: |
+          cd labs/SAW/proof
+          clang ../src/addRow.c -o ../src/addRow.bc -c -emit-llvm
+          python3 addRow.py
       # Run null SAW Script
-      - run: cd labs/SAW/proof && clang ../src/null.c -o ../src/null.bc -c -emit-llvm && python3 null.py
+      - run: |
+          cd labs/SAW/proof
+          clang ../src/null.c -o ../src/null.bc -c -emit-llvm
+          python3 null.py
       # Run Game SAW Script
-      - run: cd labs/SAW/Game/DLC && mkdir artifacts && clang -c -g -emit-llvm -o artifacts/Game.bc src/Game.c && python3 proof/Game.py
+      - run: |
+          cd labs/SAW/Game/DLC
+          mkdir artifacts
+          clang -c -g -emit-llvm -o artifacts/Game.bc src/Game.c
+          python3 proof/Game.py
       # Run ceilLog2 SAW Script
       - run: |
           cd labs/SAW/ceilLog2

--- a/.github/workflows/python-saw.yml
+++ b/.github/workflows/python-saw.yml
@@ -66,4 +66,6 @@ jobs:
       # Run Game SAW Script
       - run: cd labs/SAW/Game/DLC && mkdir artifacts && clang -c -g -emit-llvm -o artifacts/Game.bc src/Game.c && python3 proof/Game.py
       # Run ceilLog2 SAW Script
-      - run: cd labs/SAW/ceilLog2 && mkdir artifacts && clang -c -g -emit-llvm -o artifacts/ceilLog2.bc src/ceilLog2.c && python3 proof/ceilLog2.py
+      - run: |
+          cd labs/SAW/ceilLog2
+          make prove

--- a/labs/SAW/Game/DLC/Makefile
+++ b/labs/SAW/Game/DLC/Makefile
@@ -14,7 +14,7 @@ all: artifacts
 	python3 $(PROOF)/Game.py
 
 artifacts:
-	mkdir $(ARTIFACTS)
+	mkdir -p $(ARTIFACTS)
 
 clean:
 	rm -r $(ARTIFACTS)

--- a/labs/SAW/Game/Makefile
+++ b/labs/SAW/Game/Makefile
@@ -14,7 +14,7 @@ all: artifacts
 	python3 $(PROOF)/Game.py
 
 artifacts:
-	mkdir $(ARTIFACTS)
+	mkdir -p $(ARTIFACTS)
 
 clean:
 	rm -r $(ARTIFACTS)

--- a/labs/SAW/SAW.md
+++ b/labs/SAW/SAW.md
@@ -2005,8 +2005,12 @@ The lesson here, beware of `float`s claiming to mimic `int`s. Now instead of usi
 int __builtin_clzll (unsigned long long)
 ```
 
-However, let's keep with our current `ceilLog2` function and add a precondition to
-our SAW contract.
+As a bonus exercise, try to verify `__builtin_clzll`. Check out
+[ceilLog2.py](./ceilLog2/proof/ceilLog2.py) to compare your results.
+
+However, let's go back to our current `ceilLog2` function that uses
+`ceil(log2(i))`. We'll add a precondition to our SAW contract to account
+for the disparity we mentioned earlier.
 
 ```python
 class ceilLog2Contract(Contract):

--- a/labs/SAW/ceilLog2/Makefile
+++ b/labs/SAW/ceilLog2/Makefile
@@ -14,7 +14,7 @@ all: artifacts
 	python3 $(PROOF)/ceilLog2.py
 
 artifacts:
-	mkdir $(ARTIFACTS)
+	mkdir -p $(ARTIFACTS)
 
 clean:
 	rm -r $(ARTIFACTS)

--- a/labs/SAW/ceilLog2/Makefile
+++ b/labs/SAW/ceilLog2/Makefile
@@ -7,14 +7,14 @@ PROOF=proof
 SPECS=specs
 ARTIFACTS=artifacts
 
-# Note: -g flag compiles the code with debug symbols enabled.
-#       The flag lets us pass field names in addition to indices for structs.
-all: artifacts
-	clang -c -g -emit-llvm -o $(ARTIFACTS)/ceilLog2.bc $(SRC)/ceilLog2.c
+all: build
+
+prove: build
 	python3 $(PROOF)/ceilLog2.py
 
-artifacts:
+build:
 	mkdir -p $(ARTIFACTS)
+	clang -c -g -emit-llvm -o $(ARTIFACTS)/ceilLog2.bc $(SRC)/ceilLog2.c
 
 clean:
 	rm -r $(ARTIFACTS)

--- a/labs/SAW/ceilLog2/Makefile
+++ b/labs/SAW/ceilLog2/Makefile
@@ -1,0 +1,20 @@
+# Note: Makefile assumes user already started the SAW remote API
+# $ start-saw-remote-api
+
+# Variables to hold relative file paths
+SRC=src
+PROOF=proof
+SPECS=specs
+ARTIFACTS=artifacts
+
+# Note: -g flag compiles the code with debug symbols enabled.
+#       The flag lets us pass field names in addition to indices for structs.
+all: artifacts
+	clang -c -g -emit-llvm -o $(ARTIFACTS)/ceilLog2.bc $(SRC)/ceilLog2.c
+	python3 $(PROOF)/ceilLog2.py
+
+artifacts:
+	mkdir $(ARTIFACTS)
+
+clean:
+	rm -r $(ARTIFACTS)

--- a/labs/SAW/ceilLog2/proof/ceilLog2.py
+++ b/labs/SAW/ceilLog2/proof/ceilLog2.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+from unittest import TestCase, main
+
+from saw_client import LogResults, connect, llvm_load_module, llvm_verify, view
+from saw_client.crucible import Contract
+from saw_client.llvm import i64
+
+class Contract_ceilLog2(Contract):
+    def specification(self):
+        i = self.fresh_var(i64, "i")
+        
+        self.execute_func(i)
+
+        self.returns_f("lg2 {i}")
+
+class Test_(TestCase):
+  def test_(self):
+    connect(reset_server=True)
+    if __name__ == "__main__": view(LogResults(verbose_failure=True))
+
+    project_root = Path(__file__).parents[1]
+    bcname  = project_root / "artifacts/ceilLog2.bc"
+
+    mod = llvm_load_module(str(bcname))
+    
+    ceilLog2_result = llvm_verify(mod, 'ceilLog2', Contract_ceilLog2())
+    self.assertTrue(ceilLog2_result.is_success())
+
+if __name__ == "__main__":
+    main()

--- a/labs/SAW/ceilLog2/src/ceilLog2.c
+++ b/labs/SAW/ceilLog2/src/ceilLog2.c
@@ -1,0 +1,5 @@
+#include <stdint.h>
+
+uint64_t ceilLog2(uint64_t i) {
+  return (i <= 1 ? 0 : 64 - __builtin_clzll(i - 1));
+}


### PR DESCRIPTION
# Features:
- Included a new directory, `labs/SAW/ceilLog2`
- Added Matt's source code and proof for the `CLZ` implementation of `ceilLog2`
- Added a Makefile in the `ceilLog2` directory to run the example
- Updated SAW.md to mention the CLZ verification as a bonus exercise