### PR TITLE
Improvements to SAW Lab Proofs and Makefiles

### DIFF
--- a/.github/workflows/python-saw.yml
+++ b/.github/workflows/python-saw.yml
@@ -59,21 +59,16 @@ jobs:
       - run: start-saw-remote-api-read-only
       # Run final rotl SAW Script
       - run: |
-          cd labs/SAW/rotl
-          make prove
+          make prove -C labs/SAW/rotl
       # Run addRow SAW Script
       - run: |
-          cd labs/SAW/addRow
-          make prove
+          make prove -C labs/SAW/addRow
       # Run null SAW Script
       - run: |
-          cd labs/SAW/null
-          make prove
+          make prove -C labs/SAW/null
       # Run Game SAW Script
       - run: |
-          cd labs/SAW/Game/DLC
-          make prove
+          make prove -C labs/SAW/Game/DLC
       # Run ceilLog2 SAW Script
       - run: |
-          cd labs/SAW/ceilLog2
-          make prove
+          make prove -C labs/SAW/ceilLog2

--- a/labs/SAW/Game/DLC/Makefile
+++ b/labs/SAW/Game/DLC/Makefile
@@ -1,29 +1,5 @@
-# Note: Makefile assumes user already started the SAW remote API
-# $ start-saw-remote-api
-
 # Lab name
 LAB=Game
 
-# Variables to hold relative file paths
-SRC=src
-PROOF=proof
-SPECS=specs
-ARTIFACTS=artifacts
-
-all: build
-
-build: $(ARTIFACTS)/$(LAB).bc
-
-prove: build
-	python3 $(PROOF)/$(LAB).py
-
-clean:
-	rm -rf $(ARTIFACTS)
-
-.PHONY: all build prove clean
-
-$(ARTIFACTS)/$(LAB).bc: $(SRC)/$(LAB).c | $(ARTIFACTS)
-	clang -c -g -emit-llvm -o $@ $<
-
-$(ARTIFACTS):
-	mkdir -p $(ARTIFACTS)
+# Include the base Makefile format
+include ../../prove.mk

--- a/labs/SAW/Game/DLC/Makefile
+++ b/labs/SAW/Game/DLC/Makefile
@@ -1,6 +1,9 @@
 # Note: Makefile assumes user already started the SAW remote API
 # $ start-saw-remote-api
 
+# Lab name
+LAB=Game
+
 # Variables to hold relative file paths
 SRC=src
 PROOF=proof
@@ -9,12 +12,18 @@ ARTIFACTS=artifacts
 
 all: build
 
-prove: build
-	python3 $(PROOF)/Game.py
+build: $(ARTIFACTS)/$(LAB).bc
 
-build:
-	mkdir -p $(ARTIFACTS)
-	clang -c -g -emit-llvm -o $(ARTIFACTS)/Game.bc $(SRC)/Game.c
+prove: build
+	python3 $(PROOF)/$(LAB).py
 
 clean:
-	rm -r $(ARTIFACTS)
+	rm -rf $(ARTIFACTS)
+
+.PHONY: all build prove clean
+
+$(ARTIFACTS)/$(LAB).bc: $(SRC)/$(LAB).c | $(ARTIFACTS)
+	clang -c -g -emit-llvm -o $@ $<
+
+$(ARTIFACTS):
+	mkdir -p $(ARTIFACTS)

--- a/labs/SAW/Game/DLC/proof/Game.py
+++ b/labs/SAW/Game/DLC/proof/Game.py
@@ -2,7 +2,7 @@
 # Imporant Imports
 #######################################
 
-import os
+from pathlib import Path
 import unittest
 from saw_client             import *
 from saw_client.crucible    import * 
@@ -509,12 +509,12 @@ class GameTests(unittest.TestCase):
     connect(reset_server=True)
     if __name__ == "__main__": view(LogResults(verbose_failure=True))
 
-    pwd = os.getcwd()
-    bitcode_name = pwd + "/artifacts/Game.bc"
-    cryptol_name = pwd + "/specs/Game.cry"
+    basedir = Path(__file__).absolute().parents[1] # Get absolute path to Game/DLC/
+    bcpath  = basedir/"artifacts/Game.bc"
+    crypath = basedir/"specs/Game.cry"
 
-    cryptol_load_file(cryptol_name)
-    module = llvm_load_module(bitcode_name)
+    cryptol_load_file(str(crypath))
+    module = llvm_load_module(str(bcpath))
 
     # Override(s) associated with basic SAW setup
     levelUp_result             = llvm_verify(module, 'levelUp', levelUp_Contract())

--- a/labs/SAW/Game/Makefile
+++ b/labs/SAW/Game/Makefile
@@ -1,29 +1,5 @@
-# Note: Makefile assumes user already started the SAW remote API
-# $ start-saw-remote-api
-
 # Lab name
 LAB=Game
 
-# Variables to hold relative file paths
-SRC=src
-PROOF=proof
-SPECS=specs
-ARTIFACTS=artifacts
-
-all: build
-
-build: $(ARTIFACTS)/$(LAB).bc
-
-prove: build
-	python3 $(PROOF)/$(LAB).py
-
-clean:
-	rm -rf $(ARTIFACTS)
-
-.PHONY: all build prove clean
-
-$(ARTIFACTS)/$(LAB).bc: $(SRC)/$(LAB).c | $(ARTIFACTS)
-	clang -c -g -emit-llvm -o $@ $<
-
-$(ARTIFACTS):
-	mkdir -p $(ARTIFACTS)
+# Include the base Makefile format
+include ../prove.mk

--- a/labs/SAW/Game/Makefile
+++ b/labs/SAW/Game/Makefile
@@ -1,6 +1,9 @@
 # Note: Makefile assumes user already started the SAW remote API
 # $ start-saw-remote-api
 
+# Lab name
+LAB=Game
+
 # Variables to hold relative file paths
 SRC=src
 PROOF=proof
@@ -9,12 +12,18 @@ ARTIFACTS=artifacts
 
 all: build
 
-prove: build
-	python3 $(PROOF)/Game.py
+build: $(ARTIFACTS)/$(LAB).bc
 
-build:
-	mkdir -p $(ARTIFACTS)
-	clang -c -g -emit-llvm -o $(ARTIFACTS)/Game.bc $(SRC)/Game.c
+prove: build
+	python3 $(PROOF)/$(LAB).py
 
 clean:
-	rm -r $(ARTIFACTS)
+	rm -rf $(ARTIFACTS)
+
+.PHONY: all build prove clean
+
+$(ARTIFACTS)/$(LAB).bc: $(SRC)/$(LAB).c | $(ARTIFACTS)
+	clang -c -g -emit-llvm -o $@ $<
+
+$(ARTIFACTS):
+	mkdir -p $(ARTIFACTS)

--- a/labs/SAW/Game/proof/Game.py
+++ b/labs/SAW/Game/proof/Game.py
@@ -2,7 +2,7 @@
 # Imporant Imports
 #######################################
 
-import os
+from pathlib import Path
 import unittest
 from saw_client             import *
 from saw_client.crucible    import * 
@@ -128,12 +128,12 @@ class GameTests(unittest.TestCase):
     connect(reset_server=True)
     if __name__ == "__main__": view(LogResults(verbose_failure=True))
 
-    pwd = os.getcwd()
-    bitcode_name = pwd + "/artifacts/Game.bc"
-    cryptol_name = pwd + "/specs/Game.cry"
+    basedir = Path(__file__).absolute().parents[1] # Get absolute path to Game/
+    bcpath  = basedir/"artifacts/Game.bc"
+    crypath = basedir/"specs/Game.cry"
 
-    cryptol_load_file(cryptol_name)
-    module = llvm_load_module(bitcode_name)
+    cryptol_load_file(str(crypath))
+    mod = llvm_load_module(str(bcpath))
 
     # TODO: Set up verification overrides
 

--- a/labs/SAW/Game/proof/Game_answers.py
+++ b/labs/SAW/Game/proof/Game_answers.py
@@ -2,7 +2,7 @@
 # Imporant Imports
 #######################################
 
-import os
+from pathlib import Path
 import unittest
 from saw_client             import *
 from saw_client.crucible    import * 
@@ -186,12 +186,12 @@ class GameTests(unittest.TestCase):
     connect(reset_server=True)
     if __name__ == "__main__": view(LogResults(verbose_failure=True))
 
-    pwd = os.getcwd()
-    bitcode_name = pwd + "/artifacts/Game.bc"
-    cryptol_name = pwd + "/specs/Game.cry"
+    basedir = Path(__file__).absolute().parents[1] # Get absolute path to Game/
+    bcpath  = basedir/"artifacts/Game.bc"
+    crypath = basedir/"specs/Game.cry"
 
-    cryptol_load_file(cryptol_name)
-    module = llvm_load_module(bitcode_name)
+    cryptol_load_file(str(crypath))
+    module = llvm_load_module(str(bcpath))
 
     # Set up verification overrides
     initDefaultPlayer_result   = llvm_verify(module, 'initDefaultPlayer', initDefaultPlayer_Contract())

--- a/labs/SAW/SAW.md
+++ b/labs/SAW/SAW.md
@@ -265,11 +265,11 @@ class rotlTest(unittest.TestCase):
     connect(reset_server=True)
     if __name__ == "__main__": view(LogResults(verbose_failure=True))
     
-    bcname = "/some/path/to/your/file.bc"
-    mod    = llvm_load_module(bcname)
+    bcpath = "/some/path/to/your/file.bc"
+    mod    = llvm_load_module(bcpath)
     
-    cryname = "/some/path/to/your/file.cry"
-    cryptol_load_file(cryname)
+    crypath = "/some/path/to/your/file.cry"
+    cryptol_load_file(crypath)
     
     rotl_result = llvm_verify(mod, 'rotl', rotl_Contract())
     self.assertIs(rotl_result.is_success(), True)
@@ -289,14 +289,14 @@ Let's break down the first few lines of this function:
   with verbose error messages. If you don't want verbose error
   messages, then just use `if __name__ == "__main__":
   view(LogResults())`.
-- The line `bcname = "/some/path/to/your/file.bc"` declares the
+- The line `bcpath = "/some/path/to/your/file.bc"` declares the
   bitcode file to analyze. If there are multiple bitcode files,
   make a variable for each file.
-- The line `mod = llvm_load_module(bcname)` creates the object to
+- The line `mod = llvm_load_module(bcpath)` creates the object to
   pass to verification that represents the bitcode.
-- The line `cryname = "/some/path/to/your/file.cry"` specifies the
+- The line `crypath = "/some/path/to/your/file.cry"` specifies the
   path to a Cryptol specification.
-- The line `cryptol_load_file(cryname)` loads a Cryptol specification.
+- The line `cryptol_load_file(crypath)` loads a Cryptol specification.
 
 Now that the environment is set up, let's actually verify our
 contract! This is done at the line
@@ -315,7 +315,7 @@ using `self.assertIs(rotl_result.is_success(), True)`.
   <summary>Click here for the full code</summary>
 
 ```python
-import os
+from pathlib import Path
 import unittest
 from saw_client             import *
 from saw_client.crucible    import * 
@@ -337,12 +337,12 @@ class rotlTest(unittest.TestCase):
     connect(reset_server=True)
     if __name__ == "__main__": view(LogResults(verbose_failure=True))
     
-    pwd = os.getcwd()
-    bcname  = pwd + "/artifacts/rotl.bc"
-    cryname = pwd + "/specs/rotl.cry"
-    
-    cryptol_load_file(cryname)
-    mod = llvm_load_module(bcname)
+    basedir = Path(__file__).absolute().parents[1]
+    bcpath  = basedir/"artifacts/rotl.bc"
+    crypath = basedir/"specs/rotl.cry"
+
+    cryptol_load_file(str(crypath))
+    mod = llvm_load_module(str(bcpath))
     
     rotl_result = llvm_verify(mod, 'rotl', rotl_Contract())
     self.assertIs(rotl_result.is_success(), True)
@@ -775,11 +775,11 @@ class ArrayTests(unittest.TestCase):
     connect(reset_server=True)
     if __name__ == "__main__": view(LogResults(verbose_failure=True))
     
-    bcname  = "/some/path/to/your/file.bc"
-    cryname = "/some/path/to/your/file.cry"
+    bcpath  = "/some/path/to/your/file.bc"
+    crypath = "/some/path/to/your/file.cry"
     
-    cryptol_load_file(cryname)
-    mod = llvm_load_module(bcname)
+    cryptol_load_file(crypath)
+    mod = llvm_load_module(bcpath)
     
     arrayAddNewVar05_result = llvm_verify(mod, 'addRowAlias', addRowAlias_Contract(5))
     arrayAddNewVar10_result = llvm_verify(mod, 'addRowAlias', addRowAlias_Contract(10))
@@ -791,6 +791,7 @@ class ArrayTests(unittest.TestCase):
 
 {% raw %}
 ```python
+from pathlib import Path
 import unittest
 from saw_client             import *
 from saw_client.crucible    import * 
@@ -847,12 +848,12 @@ class ArrayTests(unittest.TestCase):
     connect(reset_server=True)
     if __name__ == "__main__": view(LogResults(verbose_failure=True))
     
-    pwd = os.getcwd()
-    bcname  = pwd + "/artifacts/addRow.bc"
-    cryname = pwd + "/specs/addRow.cry"
+    basedir = Path(__file__).absolute().parents[1]
+    bcpath  = basedir/"artifacts/addRow.bc"
+    crypath = basedir/"specs/addRow.cry"
     
-    cryptol_load_file(cryname)
-    mod = llvm_load_module(bcname)
+    cryptol_load_file(str(crypath))
+    mod = llvm_load_module(str(bcpath))
     
     addRow5Mutate_result = llvm_verify(mod, 'addRowMutate', addRowMutate_Contract())
     self.assertIs(addRow5Mutate_result.is_success(), True)
@@ -874,8 +875,8 @@ What do you think will happen if we run this code?
   Running the code, SAW verifies the first two contracts
   
   ```sh
-  $ cd labs/SAW/addRow
-  $ make prove
+  $ make prove -C labs/SAW/addRow
+  make: Entering directory '/workspace/cryptol-course/labs/SAW/addRow'
   mkdir -p artifacts
   clang -c -g -emit-llvm -o artifacts/addRow.bc src/addRow.c
   python3 proof/addRow.py
@@ -1060,6 +1061,7 @@ int f(int *x) {
 The following contract has possibly unexpected behavior (in C booleans are encoded as `0` for false and `1` for true).
 
 ```python
+from pathlib import Path
 import unittest
 from saw_client          import *
 from saw_client.crucible import *
@@ -1079,9 +1081,9 @@ class LLVMAssertNullTest(unittest.TestCase):
         connect(reset_server=True)
         if __name__ == "__main__": view(LogResults(verbose_failure=True))
 
-        pwd = os.getcwd()
-        bcname = pwd + "/artifacts/null.bc"
-        mod    = llvm_load_module(bcname)
+        basedir = Path(__file__).absolute().parents[1]
+        bcpath  = basedir/"artifacts/null.bc"
+        mod     = llvm_load_module(str(bcpath))
 
         result = llvm_verify(mod, 'f', FContract())
         self.assertIs(result.is_success(), True)
@@ -1094,8 +1096,8 @@ if __name__ == "__main__":
 It turns out the contract above will fail!
   
 ```sh
-$ cd labs/SAW/null
-$ make prove
+$ make prove -C labs/SAW/null
+make: Entering directory '/workspace/cryptol-course/labs/SAW/null'
 mkdir -p artifacts
 clang -c -g -emit-llvm -o artifacts/null.bc src/null.c
 python3 proof/null.py
@@ -1535,7 +1537,7 @@ Our function, `resolveAttack`, takes two inputs:
 
 Think about how to make a SAW contract for this function. Go ahead and try it if you'd like! We'll wait for you :)
 
-Got an idea, great! Let's go over the steps we need to go through...
+Got an idea? Great! Let's go over the steps we need to go through...
 
 First, let's set up our basic format for the contract:
 
@@ -1626,12 +1628,12 @@ class GameTests(unittest.TestCase):
     connect(reset_server=True)
     if __name__ == "__main__": view(LogResults(verbose_failure=True))
 
-    pwd = os.getcwd()
-    bitcode_name = pwd + "/artifacts/Game.bc"
-    cryptol_name = pwd + "/specs/Game.cry"
+    basedir = Path(__file__).absolute().parents[1]
+    bcpath  = basedir/"artifacts/Game.bc"
+    crypath = basedir/"specs/Game.cry"
 
-    cryptol_load_file(cryptol_name)
-    module = llvm_load_module(bitcode_name)
+    cryptol_load_file(str(crypath))
+    module = llvm_load_module(str(bcpath))
 
     resolveAttack_case1_result = llvm_verify(module, 'resolveAttack', resolveAttack_Contract(1))
     resolveAttack_case2_result = llvm_verify(module, 'resolveAttack', resolveAttack_Contract(2))

--- a/labs/SAW/SAW.md
+++ b/labs/SAW/SAW.md
@@ -359,7 +359,27 @@ if __name__ == "__main__":
 ```
 
 or else the python script won't do anything!
-  
+
+Note that we defined our bitcode and cryptol file paths (`bcpath` and 
+`crypath`, respectively) relative to the rotl lab directory using 
+`Path` from Python's [pathlib](https://docs.python.org/3/library/pathlib.html)
+library.
+
+```python
+    basedir = Path(__file__).absolute().parents[1]
+    bcpath  = basedir/"artifacts/rotl.bc"
+    crypath = basedir/"specs/rotl.cry"
+
+    cryptol_load_file(str(crypath))
+    mod = llvm_load_module(str(bcpath))
+```
+
+Doing so gives us freedom to call the proof script from any initial
+working directory. It also provides portability to multiple platforms
+since we don't need to worry whether or not the operating system uses
+`/` or `\` in paths. However, we must convert the path names to a 
+string so to satisfy SAW's API for file loads.
+
 </details>
 
 We can now run the proof script.

--- a/labs/SAW/addRow/Makefile
+++ b/labs/SAW/addRow/Makefile
@@ -1,6 +1,9 @@
 # Note: Makefile assumes user already started the SAW remote API
 # $ start-saw-remote-api
 
+# Lab name
+LAB=addRow
+
 # Variables to hold relative file paths
 SRC=src
 PROOF=proof
@@ -9,12 +12,18 @@ ARTIFACTS=artifacts
 
 all: build
 
-prove: build
-	python3 $(PROOF)/addRow.py
+build: $(ARTIFACTS)/$(LAB).bc
 
-build:
-	mkdir -p $(ARTIFACTS)
-	clang -c -g -emit-llvm -o $(ARTIFACTS)/addRow.bc $(SRC)/addRow.c
+prove: build
+	python3 $(PROOF)/$(LAB).py
 
 clean:
-	rm -r $(ARTIFACTS)
+	rm -rf $(ARTIFACTS)
+
+.PHONY: all build prove clean
+
+$(ARTIFACTS)/$(LAB).bc: $(SRC)/$(LAB).c | $(ARTIFACTS)
+	clang -c -g -emit-llvm -o $@ $<
+
+$(ARTIFACTS):
+	mkdir -p $(ARTIFACTS)

--- a/labs/SAW/addRow/Makefile
+++ b/labs/SAW/addRow/Makefile
@@ -1,29 +1,5 @@
-# Note: Makefile assumes user already started the SAW remote API
-# $ start-saw-remote-api
-
 # Lab name
 LAB=addRow
 
-# Variables to hold relative file paths
-SRC=src
-PROOF=proof
-SPECS=specs
-ARTIFACTS=artifacts
-
-all: build
-
-build: $(ARTIFACTS)/$(LAB).bc
-
-prove: build
-	python3 $(PROOF)/$(LAB).py
-
-clean:
-	rm -rf $(ARTIFACTS)
-
-.PHONY: all build prove clean
-
-$(ARTIFACTS)/$(LAB).bc: $(SRC)/$(LAB).c | $(ARTIFACTS)
-	clang -c -g -emit-llvm -o $@ $<
-
-$(ARTIFACTS):
-	mkdir -p $(ARTIFACTS)
+# Include the base Makefile format
+include ../prove.mk

--- a/labs/SAW/addRow/proof/addRow.py
+++ b/labs/SAW/addRow/proof/addRow.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 import unittest
 from saw_client             import *
 from saw_client.crucible    import *
@@ -58,12 +58,12 @@ class ArrayTests(unittest.TestCase):
         connect(reset_server=True)
         if __name__ == "__main__": view(LogResults(verbose_failure=True))
 
-        pwd = os.getcwd()
-        bcname  = pwd + "/artifacts/addRow.bc"
-        cryname = pwd + "/specs/addRow.cry"
+        basedir = Path(__file__).absolute().parents[1] # Get absolute path to addRow/
+        bcpath  = basedir/"artifacts/addRow.bc"
+        crypath = basedir/"specs/addRow.cry"
 
-        cryptol_load_file(cryname)
-        mod = llvm_load_module(bcname)
+        cryptol_load_file(str(crypath))
+        mod = llvm_load_module(str(bcpath))
 
         addRow5Mutate_result = llvm_verify(mod, 'addRow5Mutate', addRow5Mutate_Contract())
         self.assertIs(addRow5Mutate_result.is_success(), True)

--- a/labs/SAW/ceilLog2/Makefile
+++ b/labs/SAW/ceilLog2/Makefile
@@ -1,6 +1,9 @@
 # Note: Makefile assumes user already started the SAW remote API
 # $ start-saw-remote-api
 
+# Lab name
+LAB=ceilLog2
+
 # Variables to hold relative file paths
 SRC=src
 PROOF=proof
@@ -9,12 +12,18 @@ ARTIFACTS=artifacts
 
 all: build
 
-prove: build
-	python3 $(PROOF)/ceilLog2.py
+build: $(ARTIFACTS)/$(LAB).bc
 
-build:
-	mkdir -p $(ARTIFACTS)
-	clang -c -g -emit-llvm -o $(ARTIFACTS)/ceilLog2.bc $(SRC)/ceilLog2.c
+prove: build
+	python3 $(PROOF)/$(LAB).py
 
 clean:
-	rm -r $(ARTIFACTS)
+	rm -rf $(ARTIFACTS)
+
+.PHONY: all build prove clean
+
+$(ARTIFACTS)/$(LAB).bc: $(SRC)/$(LAB).c | $(ARTIFACTS)
+	clang -c -g -emit-llvm -o $@ $<
+
+$(ARTIFACTS):
+	mkdir -p $(ARTIFACTS)

--- a/labs/SAW/ceilLog2/Makefile
+++ b/labs/SAW/ceilLog2/Makefile
@@ -1,29 +1,5 @@
-# Note: Makefile assumes user already started the SAW remote API
-# $ start-saw-remote-api
-
 # Lab name
 LAB=ceilLog2
 
-# Variables to hold relative file paths
-SRC=src
-PROOF=proof
-SPECS=specs
-ARTIFACTS=artifacts
-
-all: build
-
-build: $(ARTIFACTS)/$(LAB).bc
-
-prove: build
-	python3 $(PROOF)/$(LAB).py
-
-clean:
-	rm -rf $(ARTIFACTS)
-
-.PHONY: all build prove clean
-
-$(ARTIFACTS)/$(LAB).bc: $(SRC)/$(LAB).c | $(ARTIFACTS)
-	clang -c -g -emit-llvm -o $@ $<
-
-$(ARTIFACTS):
-	mkdir -p $(ARTIFACTS)
+# Include the base Makefile format
+include ../prove.mk

--- a/labs/SAW/ceilLog2/proof/ceilLog2.py
+++ b/labs/SAW/ceilLog2/proof/ceilLog2.py
@@ -18,10 +18,9 @@ class Test_(TestCase):
     connect(reset_server=True)
     if __name__ == "__main__": view(LogResults(verbose_failure=True))
 
-    project_root = Path(__file__).parents[1]
-    bcname = project_root / "artifacts/ceilLog2.bc"
-
-    mod = llvm_load_module(str(bcname))
+    basedir = Path(__file__).absolute().parents[1] # Get absolute path to ceilLog2/
+    bcpath = basedir/"artifacts/ceilLog2.bc"
+    mod = llvm_load_module(str(bcpath))
     
     ceilLog2_result = llvm_verify(mod, 'ceilLog2', Contract_ceilLog2())
     self.assertTrue(ceilLog2_result.is_success())

--- a/labs/SAW/null/Makefile
+++ b/labs/SAW/null/Makefile
@@ -9,12 +9,18 @@ ARTIFACTS=artifacts
 
 all: build
 
+build: $(ARTIFACTS)/null.bc
+
 prove: build
 	python3 $(PROOF)/null.py
 
-build:
-	mkdir -p $(ARTIFACTS)
-	clang -c -g -emit-llvm -o $(ARTIFACTS)/null.bc $(SRC)/null.c
-
 clean:
 	rm -r $(ARTIFACTS)
+
+.PHONY: all build prove clean
+
+$(ARTIFACTS)/null.bc: $(SRC)/null.c | $(ARTIFACTS)
+	clang -c -g -emit-llvm -o $@ $<
+
+$(ARTIFACTS):
+	mkdir -p $(ARTIFACTS)

--- a/labs/SAW/null/Makefile
+++ b/labs/SAW/null/Makefile
@@ -1,29 +1,5 @@
-# Note: Makefile assumes user already started the SAW remote API
-# $ start-saw-remote-api
-
 # Lab name
 LAB=null
 
-# Variables to hold relative file paths
-SRC=src
-PROOF=proof
-SPECS=specs
-ARTIFACTS=artifacts
-
-all: build
-
-build: $(ARTIFACTS)/$(LAB).bc
-
-prove: build
-	python3 $(PROOF)/$(LAB).py
-
-clean:
-	rm -rf $(ARTIFACTS)
-
-.PHONY: all build prove clean
-
-$(ARTIFACTS)/$(LAB).bc: $(SRC)/$(LAB).c | $(ARTIFACTS)
-	clang -c -g -emit-llvm -o $@ $<
-
-$(ARTIFACTS):
-	mkdir -p $(ARTIFACTS)
+# Include the base Makefile format
+include ../prove.mk

--- a/labs/SAW/null/Makefile
+++ b/labs/SAW/null/Makefile
@@ -1,6 +1,9 @@
 # Note: Makefile assumes user already started the SAW remote API
 # $ start-saw-remote-api
 
+# Lab name
+LAB=null
+
 # Variables to hold relative file paths
 SRC=src
 PROOF=proof
@@ -9,17 +12,17 @@ ARTIFACTS=artifacts
 
 all: build
 
-build: $(ARTIFACTS)/null.bc
+build: $(ARTIFACTS)/$(LAB).bc
 
 prove: build
-	python3 $(PROOF)/null.py
+	python3 $(PROOF)/$(LAB).py
 
 clean:
-	rm -r $(ARTIFACTS)
+	rm -rf $(ARTIFACTS)
 
 .PHONY: all build prove clean
 
-$(ARTIFACTS)/null.bc: $(SRC)/null.c | $(ARTIFACTS)
+$(ARTIFACTS)/$(LAB).bc: $(SRC)/$(LAB).c | $(ARTIFACTS)
 	clang -c -g -emit-llvm -o $@ $<
 
 $(ARTIFACTS):

--- a/labs/SAW/null/proof/null.py
+++ b/labs/SAW/null/proof/null.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from pathlib import Path
 from saw_client          import *
 from saw_client.crucible import *
 from saw_client.llvm     import *
@@ -19,9 +20,9 @@ class LLVMAssertNullTest(unittest.TestCase):
         connect(reset_server=True)
         if __name__ == "__main__": view(LogResults(verbose_failure=True))
 
-        pwd = os.getcwd()
-        bcname = pwd + "/artifacts/null.bc"
-        mod    = llvm_load_module(bcname)
+        basedir = Path(__file__).absolute().parents[1] # Get absolute path to null/
+        bcpath  = basedir/"artifacts/null.bc"
+        mod     = llvm_load_module(str(bcpath))
 
         result = llvm_verify(mod, 'isNull', isNull_Contract())
         self.assertIs(result.is_success(), True)

--- a/labs/SAW/null/proof/null.py
+++ b/labs/SAW/null/proof/null.py
@@ -1,6 +1,5 @@
-import os
-import unittest
 from pathlib import Path
+import unittest
 from saw_client          import *
 from saw_client.crucible import *
 from saw_client.llvm     import *

--- a/labs/SAW/prove.mk
+++ b/labs/SAW/prove.mk
@@ -1,0 +1,26 @@
+# Note: Makefile assumes user already started the SAW remote API
+# $ start-saw-remote-api
+
+# Variables to hold relative file paths
+SRC=src
+PROOF=proof
+SPECS=specs
+ARTIFACTS=artifacts
+
+all: build
+
+build: $(ARTIFACTS)/$(LAB).bc
+
+prove: build
+	python3 $(PROOF)/$(LAB).py
+
+clean:
+	rm -rf $(ARTIFACTS)
+
+.PHONY: all build prove clean
+
+$(ARTIFACTS)/$(LAB).bc: $(SRC)/$(LAB).c | $(ARTIFACTS)
+	clang -c -g -emit-llvm -o $@ $<
+
+$(ARTIFACTS):
+	mkdir -p $(ARTIFACTS)

--- a/labs/SAW/rotl/Makefile
+++ b/labs/SAW/rotl/Makefile
@@ -1,6 +1,9 @@
 # Note: Makefile assumes user already started the SAW remote API
 # $ start-saw-remote-api
 
+# Lab name
+LAB=rotl
+
 # Variables to hold relative file paths
 SRC=src
 PROOF=proof
@@ -9,12 +12,18 @@ ARTIFACTS=artifacts
 
 all: build
 
-prove: build
-	python3 $(PROOF)/rotl.py
+build: $(ARTIFACTS)/$(LAB).bc
 
-build:
-	mkdir -p $(ARTIFACTS)
-	clang -c -g -emit-llvm -o $(ARTIFACTS)/rotl.bc $(SRC)/rotl3.c
+prove: build
+	python3 $(PROOF)/$(LAB).py
 
 clean:
-	rm -r $(ARTIFACTS)
+	rm -rf $(ARTIFACTS)
+
+.PHONY: all build prove clean
+
+$(ARTIFACTS)/$(LAB).bc: $(SRC)/$(LAB)3.c | $(ARTIFACTS)
+	clang -c -g -emit-llvm -o $@ $<
+
+$(ARTIFACTS):
+	mkdir -p $(ARTIFACTS)

--- a/labs/SAW/rotl/proof/rotl.py
+++ b/labs/SAW/rotl/proof/rotl.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 import unittest
 from saw_client             import *
 from saw_client.crucible    import * 
@@ -20,12 +20,12 @@ class rotlTest(unittest.TestCase):
     connect(reset_server=True)
     if __name__ == "__main__": view(LogResults(verbose_failure=True))
 
-    pwd = os.getcwd()
-    bcname  = pwd + "/artifacts/rotl.bc"
-    cryname = pwd + "/specs/rotl.cry"
+    basedir = Path(__file__).absolute().parents[1] # Get absolute path to rotl/
+    bcpath  = basedir/"artifacts/rotl.bc"
+    crypath = basedir/"specs/rotl.cry"
 
-    cryptol_load_file(cryname)
-    mod = llvm_load_module(bcname)
+    cryptol_load_file(str(crypath))
+    mod = llvm_load_module(str(bcpath))
     
     rotl_result = llvm_verify(mod, 'rotl', rotl_Contract())
     self.assertIs(rotl_result.is_success(), True)


### PR DESCRIPTION
# Features
- Updates the SAW labs based on @WeeknightMVP 's comments about [relative paths for proofs](https://github.com/weaversa/cryptol-course/pull/205#issuecomment-1152993146) and [specifying targets for Makefiles](https://github.com/weaversa/cryptol-course/pull/205#issuecomment-1152995699).
  - Python proof scripts can now be called anywhere!
- Updates the python-saw CI to run SAW labs in a `make prove -C` format without the need to change directories via `cd`
- Updated the SAW lab Makefiles to be identical except for their `LAB` variables
- Updated the SAW.md documentation to reflect these changes