### PR TITLE
Modified rotl lab to follow new Makefile format

### DIFF
--- a/labs/SAW/SAW.md
+++ b/labs/SAW/SAW.md
@@ -137,7 +137,7 @@ in a terminal.
 
 ```sh
 $ mkdir labs/SAW/rotl/artifacts
-$ clang -emit-llvm labs/SAW/rotl/src/rotl.c -c -o labs/SAW/rotl/artifacts/rotl.bc
+$ clang -emit-llvm labs/SAW/rotl/src/rotl1.c -c -o labs/SAW/rotl/artifacts/rotl.bc
 ```
 
 We can inspect the bitcode, using SAW, by loading the module and
@@ -498,7 +498,7 @@ uint32_t rotl(uint32_t bits, uint32_t shift) {
 ```
 
 ```sh
-$ clang -c -emit-llvm -o artifacts/rotl.bc src/rotl3.c && python3 proof/rotl.py
+$ clang -c -emit-llvm -o artifacts/rotl.bc src/rotl.c && python3 proof/rotl.py
 [03:14:09.561] Verifying rotl ...
 [03:14:09.562] Simulating rotl ...
 [03:14:09.563] Checking proof obligations rotl ...
@@ -523,7 +523,7 @@ the bitcode for the module and run the proof!
 $ cd labs/SAW/rotl
 $ make prove
 mkdir -p artifacts
-clang -c -g -emit-llvm -o artifacts/rotl.bc src/rotl3.c
+clang -c -g -emit-llvm -o artifacts/rotl.bc src/rotl.c
 python3 proof/rotl.py
 ```
 

--- a/labs/SAW/rotl/Makefile
+++ b/labs/SAW/rotl/Makefile
@@ -1,29 +1,5 @@
-# Note: Makefile assumes user already started the SAW remote API
-# $ start-saw-remote-api
-
 # Lab name
 LAB=rotl
 
-# Variables to hold relative file paths
-SRC=src
-PROOF=proof
-SPECS=specs
-ARTIFACTS=artifacts
-
-all: build
-
-build: $(ARTIFACTS)/$(LAB).bc
-
-prove: build
-	python3 $(PROOF)/$(LAB).py
-
-clean:
-	rm -rf $(ARTIFACTS)
-
-.PHONY: all build prove clean
-
-$(ARTIFACTS)/$(LAB).bc: $(SRC)/$(LAB)3.c | $(ARTIFACTS)
-	clang -c -g -emit-llvm -o $@ $<
-
-$(ARTIFACTS):
-	mkdir -p $(ARTIFACTS)
+# Include the base Makefile format
+include ../prove.mk

--- a/labs/SAW/rotl/src/rotl.c
+++ b/labs/SAW/rotl/src/rotl.c
@@ -3,5 +3,7 @@
 #include <stdint.h>
 
 uint32_t rotl(uint32_t bits, uint32_t shift) {
+  shift %= sizeof(bits) * 8;
+  if(shift == 0) return bits;
   return (bits << shift) | (bits >> (sizeof(bits) * 8 - shift));
 }

--- a/labs/SAW/rotl/src/rotl1.c
+++ b/labs/SAW/rotl/src/rotl1.c
@@ -3,7 +3,5 @@
 #include <stdint.h>
 
 uint32_t rotl(uint32_t bits, uint32_t shift) {
-  shift %= sizeof(bits) * 8;
-  if(shift == 0) return bits;
   return (bits << shift) | (bits >> (sizeof(bits) * 8 - shift));
 }


### PR DESCRIPTION
# Features
- Updates rotl to match the other SAW labs based on the conversation in #217
- Updates `SAW.md` to reflect the name changes of `rotl.c` -> `rotl1.c` and `rotl3.c` -> `rotl.c`