### PR TITLE
Updates to sprite and character structs in response to Issue 216

### DIFF
--- a/labs/SAW/Game/DLC/proof/Game.py
+++ b/labs/SAW/Game/DLC/proof/Game.py
@@ -60,78 +60,72 @@ class levelUp_Contract(Contract):
 
 
 # initDefaultPlayer Contract
-# uint32_t initDefaultPlayer(player_t* player)
+# player_t* initDefaultPlayer()
 class initDefaultPlayer_Contract(Contract):
   def specification (self):
-    # Pull the struct from the bitcode
-    # Although the function uses player_t, pass character_t to SAW since
-    # player_t is an alternative typedef name for character_t.
-    player = self.alloc(alias_ty("struct.character_t"))
+    # No input arguments, so no need to define variables now...
 
     # Symbolically execute the function
-    self.execute_func(player)
+    self.execute_func()
+
+    # Allocate memory for the player_t struct
+    # Note: Although the function uses player_t, pass character_t to SAW since
+    #       player_t is an alternative typedef name for character_t.
+    player = self.alloc(alias_ty("struct.character_t"))
 
     # Assert the postcondition behaviors
-
-    # Option 1: Assert one field at a time via points_to
     self.points_to(player['name'], cry_f("repeat 0x41 : [{MAX_NAME_LENGTH}][8]"))
     self.points_to(player['level'], cry_f("1 : [32]"))
     self.points_to(player['hp'], cry_f("10 : [32]"))
     self.points_to(player['atk'], cry_f("5 : [32]"))
     self.points_to(player['def'], cry_f("4 : [32]"))
     self.points_to(player['spd'], cry_f("3 : [32]"))
-    # Note: If bitcode isn't compiled with debug symbols enabled (no "-g" flag)
-    #       then use the field indices instead.
-    # self.points_to(player[0], cry_f("repeat 0x41 : [{MAX_NAME_LENGTH}][8]"))
-    # self.points_to(player[1], cry_f("1 : [32]"))
-    # self.points_to(player[2], cry_f("10 : [32]"))
-    # self.points_to(player[3], cry_f("5 : [32]"))
-    # self.points_to(player[4], cry_f("4 : [32]"))
-    # self.points_to(player[5], cry_f("3 : [32]"))
+    self.points_to(player['sprite'], null())
 
-    # Option 2: Assert all of the fields to a tuple
-    # self.points_to(player, cry_f("( repeat 0x41 : [{MAX_NAME_LENGTH}][8], 1 : [32], 10 : [32], 5 : [32], 4 : [32], 3 : [32] )"))
-
-    # Pop Quiz: Why doesn't this work?
-    # self.points_to(player, cry_f("""{{ name  = repeat 0x41 : [{MAX_NAME_LENGTH}][8],
-    #                                    level = 1 : [32],
-    #                                    hp    = 10 : [32],
-    #                                    atk   = 5 : [32],
-    #                                    def   = 4 : [32],
-    #                                    spd   = 3 : [32] }}"""))
-
-    self.returns(cry_f("`({SUCCESS}) : [32]"))
+    self.returns(player)
 
 
 # initDefaultSprite Contract
-# uint32_t initDefaultSprite(character_t* character, sprite_t* sprite)
+# uint32_t initDefaultSprite(character_t* character)
 class initDefaultSprite_Contract(Contract):
   def specification (self):
     # Declare variables
-    character       = self.alloc(alias_ty("struct.character_t"))              # For Option 1
-    #character       = self.fresh_var(ptr_ty(alias_ty("struct.character_t"))) # For Option 2
-    tempCharacter_p = self.alloc(alias_ty("struct.character_t"))
-    ty              = array_ty(GAITS, array_ty(DIRECTIONS, array_ty(ANIMATION_STEPS, i8)))
-    frames          = self.fresh_var(ty, "sprite.frames")
-    xPos            = self.fresh_var(i32, "sprite.xPos")
-    yPos            = self.fresh_var(i32, "sprite.yPos")
-    sprite_p        = self.alloc(alias_ty("struct.sprite_t"), points_to = struct(tempCharacter_p, frames, xPos, yPos))
+    name     = self.fresh_var(array_ty(MAX_NAME_LENGTH, i8), "character.name")
+    level    = self.fresh_var(i32, "character.level")
+    hp       = self.fresh_var(i32, "character.hp")
+    atk      = self.fresh_var(i32, "character.atk")
+    defense  = self.fresh_var(i32, "character.def")
+    spd      = self.fresh_var(i32, "character.spd")
+    # Note: No need to allocate memory yet for the sprite_t struct since the
+    #       function assumes the passed character_t struct does not have an
+    #       allocated sprite. Instead, pass NULL as the sprite precondition.
+    character_p = self.alloc( alias_ty("struct.character_t")
+                            , points_to = struct( name
+                                                , level
+                                                , hp
+                                                , atk
+                                                , defense
+                                                , spd
+                                                , null() ))
 
     # Symbolically execute the function
-    self.execute_func(character, sprite_p)
+    self.execute_func(character_p)
 
-    # Assert postconditions
-    # Option 1: Struct Strategy
-    self.points_to(sprite_p, struct( character,
-                                     cry_f("zero : [{GAITS}][{DIRECTIONS}][{ANIMATION_STEPS}][8]"),
-                                     cry_f("1 : [32]"),
-                                     cry_f("2 : [32]") ))
-    # Option 2: Full Tuple Strategy
-    #self.points_to(sprite_p, cry_f("""( {character},
-    #                                 zero : [{GAITS}][{DIRECTIONS}][{ANIMATION_STEPS}][8],
-    #                                 1 : [32],
-    #                                 2 : [32]) """))
-                  
+    # Allocate memory for the new sprite_t struct and assert its postconditions
+    sprite_p = self.alloc( alias_ty("struct.sprite_t")
+                         , points_to = struct( cry_f("zero : [{GAITS}][{DIRECTIONS}][{ANIMATION_STEPS}][8]")
+                                             , cry_f("1 : [32]")
+                                             , cry_f("2 : [32]") ))
+
+    # Assert the postcondition for character
+    self.points_to(character_p, struct( name
+                                      , level
+                                      , hp
+                                      , atk
+                                      , defense
+                                      , spd
+                                      , sprite_p ))
+
     self.returns_f("`({SUCCESS}) : [32]")
 
 

--- a/labs/SAW/Game/DLC/src/Game.c
+++ b/labs/SAW/Game/DLC/src/Game.c
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include "Game.h"
 
 
@@ -15,8 +16,11 @@ uint32_t levelUp(uint32_t level)
 // Function(s) with basic struct initialization
 ///////////////////////////////////////
 
-uint32_t initDefaultPlayer(player_t* player)
+player_t* initDefaultPlayer()
 {
+  // Allocate memory for a player_t object
+  player_t* player = (player_t*) malloc(sizeof(player_t));
+
   // Variables
   uint8_t i = 0;
   uint32_t hp_default  = 10;
@@ -38,14 +42,34 @@ uint32_t initDefaultPlayer(player_t* player)
   player->def = def_default;
   player->spd = spd_default;
 
-  return SUCCESS;
+  // Initialize sprite to NULL
+  // Assume a development rule that the player's sprite can only be configured
+  // once. Initialize the sprite when more information about the player
+  // specifications are known.
+  player->sprite = NULL;
+
+  return player;
 }
 
 
-uint32_t initDefaultSprite(character_t* character, sprite_t* sprite)
+uint32_t initDefaultSprite(character_t* character)
 {
-  // Initialize the character to the passed pointer
-  sprite->character = character;
+  // Parameter checking
+  if (character == NULL)
+  {
+    // Must be passed an allocated character struct
+    return FAILURE;
+  }
+  else if (character->sprite != NULL)
+  {
+    // The passed character already has a sprite assigned.
+    // Follow up on the development rule that character structs can only be
+    // initialized a sprite once!
+    return FAILURE;
+  }
+
+  // Allocate memory for a sprite struct
+  sprite_t* sprite = (sprite_t*) malloc(sizeof(sprite_t));
 
   // Initialize the sprite frames to the default asset
   for (uint8_t i = 0; i < GAITS; i++)
@@ -62,6 +86,9 @@ uint32_t initDefaultSprite(character_t* character, sprite_t* sprite)
   // Initialize sprite's default position
   sprite->xPos = 1;
   sprite->yPos = 2;
+
+  // Set the sprite to the character
+  character->sprite = sprite;
 
   return SUCCESS;
 }

--- a/labs/SAW/Game/DLC/src/Game.h
+++ b/labs/SAW/Game/DLC/src/Game.h
@@ -40,6 +40,14 @@ enum battleResult{
 // Structs
 ///////////////////////////////////////
 
+// Struct containing information on a character sprite
+typedef struct {
+  uint8_t frames[GAITS][DIRECTIONS][ANIMATION_STEPS];
+  uint32_t xPos;  // x position relative to the screen
+  uint32_t yPos;  // y position relative to the screen
+} sprite_t;
+
+
 // Struct containing character information
 typedef struct {
   uint8_t name[MAX_NAME_LENGTH];
@@ -48,6 +56,7 @@ typedef struct {
   uint32_t atk;
   uint32_t def;
   uint32_t spd;
+  sprite_t* sprite;
 } character_t;
 
 typedef character_t player_t;
@@ -70,14 +79,6 @@ typedef struct {
   uint8_t tiles[SCREEN_TILES];  // Holds asset ID for each screen tile
 } screen_t;
 
-// Struct containing information on a character sprite
-typedef struct {
-  character_t* character;
-  uint8_t frames[GAITS][DIRECTIONS][ANIMATION_STEPS];
-  uint32_t xPos;  // x position relative to the screen
-  uint32_t yPos;  // y position relative to the screen
-} sprite_t;
-
 
 ///////////////////////////////////////
 // Function prototypes
@@ -87,8 +88,8 @@ typedef struct {
 uint32_t levelUp(uint32_t level);
 
 // Function(s) with basic struct initialization
-uint32_t initDefaultPlayer(player_t* player);
-uint32_t initDefaultSprite(character_t* character, sprite_t* sprite);
+player_t* initDefaultPlayer();
+uint32_t initDefaultSprite(character_t* character);
 
 // Function(s) with preconditions and postconditions that must
 // be considered in SAW contracts & unit test overrides

--- a/labs/SAW/Game/proof/Game_answers.py
+++ b/labs/SAW/Game/proof/Game_answers.py
@@ -43,13 +43,15 @@ def ptr_to_fresh(spec: Contract, ty: LLVMType,
 # uint32_t initDefaultPlayer(player_t* player)
 class initDefaultPlayer_Contract(Contract):
   def specification (self):
-    # Pull the struct from the bitcode
-    # Although the function uses player_t, pass character_t to SAW since
-    # player_t is an alternative typedef name for character_t.
-    player = self.alloc(alias_ty("struct.character_t"))
+    # No input arguments, so no need to define variables now...
 
     # Symbolically execute the function
-    self.execute_func(player)
+    self.execute_func()
+
+    # Allocate memory for the player_t struct
+    # Note: Although the function uses player_t, pass character_t to SAW since
+    #       player_t is an alternative typedef name for character_t.
+    player = self.alloc(alias_ty("struct.character_t"))
 
     # Assert the postcondition behaviors
     self.points_to(player['name'], cry_f("repeat 0x41 : [{MAX_NAME_LENGTH}][8]"))
@@ -58,8 +60,9 @@ class initDefaultPlayer_Contract(Contract):
     self.points_to(player['atk'], cry_f("5 : [32]"))
     self.points_to(player['def'], cry_f("4 : [32]"))
     self.points_to(player['spd'], cry_f("3 : [32]"))
+    self.points_to(player['sprite'], null())
 
-    self.returns(cry_f("`({SUCCESS}) : [32]"))
+    self.returns(player)
 
 
 # initDefaultSprite Contract
@@ -67,23 +70,42 @@ class initDefaultPlayer_Contract(Contract):
 class initDefaultSprite_Contract(Contract):
   def specification (self):
     # Declare variables
-    character       = self.alloc(alias_ty("struct.character_t"))
-    tempCharacter_p = self.alloc(alias_ty("struct.character_t"))
-    ty              = array_ty(GAITS, array_ty(DIRECTIONS, array_ty(ANIMATION_STEPS, i8)))
-    frames          = self.fresh_var(ty, "sprite.frames")
-    xPos            = self.fresh_var(i32, "sprite.xPos")
-    yPos            = self.fresh_var(i32, "sprite.yPos")
-    sprite_p        = self.alloc(alias_ty("struct.sprite_t"), points_to = struct(tempCharacter_p, frames, xPos, yPos))
+    name     = self.fresh_var(array_ty(MAX_NAME_LENGTH, i8), "character.name")
+    level    = self.fresh_var(i32, "character.level")
+    hp       = self.fresh_var(i32, "character.hp")
+    atk      = self.fresh_var(i32, "character.atk")
+    defense  = self.fresh_var(i32, "character.def")
+    spd      = self.fresh_var(i32, "character.spd")
+    # Note: No need to allocate memory yet for the sprite_t struct since the
+    #       function assumes the passed character_t struct does not have an
+    #       allocated sprite. Instead, pass NULL as the sprite precondition.
+    character_p = self.alloc( alias_ty("struct.character_t")
+                            , points_to = struct( name
+                                                , level
+                                                , hp
+                                                , atk
+                                                , defense
+                                                , spd
+                                                , null() ))
 
     # Symbolically execute the function
-    self.execute_func(character, sprite_p)
+    self.execute_func(character_p)
 
-    # Assert postconditions
-    self.points_to(sprite_p, struct( character,
-                                     cry_f("zero : [{GAITS}][{DIRECTIONS}][{ANIMATION_STEPS}][8]"),
-                                     cry_f("1 : [32]"),
-                                     cry_f("2 : [32]") ))
-                  
+    # Allocate memory for the new sprite_t struct and assert its postconditions
+    sprite_p = self.alloc( alias_ty("struct.sprite_t")
+                         , points_to = struct( cry_f("zero : [{GAITS}][{DIRECTIONS}][{ANIMATION_STEPS}][8]")
+                                             , cry_f("1 : [32]")
+                                             , cry_f("2 : [32]") ))
+
+    # Assert the postcondition for character
+    self.points_to(character_p, struct( name
+                                      , level
+                                      , hp
+                                      , atk
+                                      , defense
+                                      , spd
+                                      , sprite_p ))
+
     self.returns_f("`({SUCCESS}) : [32]")
 
 

--- a/labs/SAW/Game/proof/Game_answers.py
+++ b/labs/SAW/Game/proof/Game_answers.py
@@ -40,7 +40,7 @@ def ptr_to_fresh(spec: Contract, ty: LLVMType,
 #######################################
 
 # initDefaultPlayer Contract
-# uint32_t initDefaultPlayer(player_t* player)
+# player_t* initDefaultPlayer()
 class initDefaultPlayer_Contract(Contract):
   def specification (self):
     # No input arguments, so no need to define variables now...
@@ -66,7 +66,7 @@ class initDefaultPlayer_Contract(Contract):
 
 
 # initDefaultSprite Contract
-# uint32_t initDefaultSprite(character_t* character, sprite_t* sprite)
+# uint32_t initDefaultSprite(character_t* character)
 class initDefaultSprite_Contract(Contract):
   def specification (self):
     # Declare variables

--- a/labs/SAW/Game/src/Game.c
+++ b/labs/SAW/Game/src/Game.c
@@ -39,23 +39,23 @@ player_t* initDefaultPlayer()
 }
 
 
-uint32_t initDefaultSprite(player_t* player)
+uint32_t initDefaultSprite(character_t* character)
 {
   // Parameter checking
-  if (player == NULL)
+  if (character == NULL)
   {
-    // Must be passed an allocated player object
+    // Must be passed an allocated character struct
     return FAILURE;
   }
-  else if (player->sprite != NULL)
+  else if (character->sprite != NULL)
   {
-    // The passed player already has a sprite assigned.
-    // Follow up on the development rule that player objects can only be
+    // The passed character already has a sprite assigned.
+    // Follow up on the development rule that character structs can only be
     // initialized a sprite once!
     return FAILURE;
   }
 
-  // Allocate memory for a sprite object
+  // Allocate memory for a sprite struct
   sprite_t* sprite = (sprite_t*) malloc(sizeof(sprite_t));
 
   // Initialize the sprite frames to the default asset
@@ -74,8 +74,8 @@ uint32_t initDefaultSprite(player_t* player)
   sprite->xPos = 1;
   sprite->yPos = 2;
 
-  // Set the sprite to the player
-  player->sprite = sprite;
+  // Set the sprite to the character
+  character->sprite = sprite;
 
   return SUCCESS;
 }

--- a/labs/SAW/Game/src/Game.c
+++ b/labs/SAW/Game/src/Game.c
@@ -2,7 +2,6 @@
 #include "Game.h"
 
 
-// Assume player->sprite is NULL prior to the call
 player_t* initDefaultPlayer()
 {
   // Allocate memory for a player_t object

--- a/labs/SAW/Game/src/Game.c
+++ b/labs/SAW/Game/src/Game.c
@@ -1,8 +1,12 @@
 #include "Game.h"
 
 
-uint32_t initDefaultPlayer(player_t* player)
+// Assume player->sprite is NULL prior to the call
+player_t* initDefaultPlayer()
 {
+  // Allocate memory for a player_t object
+  player_t* player = (player_t*) malloc(sizeof(player_t));
+
   // Variables
   uint8_t i = 0;
   uint32_t hp_default  = 10;
@@ -24,14 +28,34 @@ uint32_t initDefaultPlayer(player_t* player)
   player->def = def_default;
   player->spd = spd_default;
 
-  return SUCCESS;
+  // Initialize sprite to NULL
+  // Assume a development rule that the player's sprite can only be configured
+  // once. Initialize the sprite when more information about the player
+  // specifications are known.
+  player->sprite = NULL;
+
+  return player;
 }
 
 
-uint32_t initDefaultSprite(character_t* character, sprite_t* sprite)
+uint32_t initDefaultSprite(player_t* player)
 {
-  // Initialize the character to the passed pointer
-  sprite->character = character;
+  // Parameter checking
+  if (player == NULL)
+  {
+    // Must be passed an allocated player object
+    return FAILURE;
+  }
+  else if (player->sprite != NULL)
+  {
+    // The passed player already has a sprite assigned.
+    // Follow up on the development rule that player objects can only be
+    // initialized a sprite once!
+    return FAILURE;
+  }
+
+  // Allocate memory for a sprite object
+  sprite_t* sprite = (sprite_t*) malloc(sizeof(sprite_t));
 
   // Initialize the sprite frames to the default asset
   for (uint8_t i = 0; i < GAITS; i++)
@@ -48,6 +72,9 @@ uint32_t initDefaultSprite(character_t* character, sprite_t* sprite)
   // Initialize sprite's default position
   sprite->xPos = 1;
   sprite->yPos = 2;
+
+  // Set the sprite to the player
+  player->sprite = sprite;
 
   return SUCCESS;
 }

--- a/labs/SAW/Game/src/Game.c
+++ b/labs/SAW/Game/src/Game.c
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include "Game.h"
 
 

--- a/labs/SAW/Game/src/Game.h
+++ b/labs/SAW/Game/src/Game.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 
 
-// Status values that provide a hamming distance of 5
+// Status values that provide a hamming distance of 8
 #define SUCCESS 170         // 170 = 0xAA = 10101010
 #define FAILURE 85          //  85 = 0x55 = 01010101
 

--- a/labs/SAW/Game/src/Game.h
+++ b/labs/SAW/Game/src/Game.h
@@ -28,13 +28,13 @@ typedef struct {
   uint32_t atk;
   uint32_t def;
   uint32_t spd;
+  sprite_t* sprite;
 } character_t;
 
 typedef character_t player_t;
 
 // Contains information related to character sprites
 typedef struct {
-  character_t* character;
   uint8_t frames[GAITS][DIRECTIONS][ANIMATION_STEPS];
   uint32_t xPos;  // x position relative to the screen
   uint32_t yPos;  // y position relative to the screen
@@ -50,7 +50,7 @@ typedef struct {
   \param player_t* player - Pointer to an allocated player variable.
   \return SUCCESS.
 **/
-uint32_t initDefaultPlayer(player_t* player);
+player_t* initDefaultPlayer();
 
 /**
   Initializes a sprite variable based on default parameters and ties the sprite
@@ -60,7 +60,7 @@ uint32_t initDefaultPlayer(player_t* player);
   \param sprite_t* sprite - Pointer to an allocated sprite variable.
   \return SUCCESS.
 **/
-uint32_t initDefaultSprite(character_t* character, sprite_t* sprite);
+uint32_t initDefaultPlayerSprite(character_t* character);
 
 /**
   Resolves a target's hp stat after an attack.

--- a/labs/SAW/Game/src/Game.h
+++ b/labs/SAW/Game/src/Game.h
@@ -61,7 +61,7 @@ player_t* initDefaultPlayer();
   \param sprite_t* sprite - Pointer to an allocated sprite variable.
   \return SUCCESS.
 **/
-uint32_t initDefaultPlayerSprite(character_t* character);
+uint32_t initDefaultSprite(character_t* character);
 
 /**
   Resolves a target's hp stat after an attack.

--- a/labs/SAW/Game/src/Game.h
+++ b/labs/SAW/Game/src/Game.h
@@ -48,18 +48,19 @@ typedef character_t player_t;
 
 /**
   Initializes a player variable based on default parameters.
-  \param player_t* player - Pointer to an allocated player variable.
-  \return SUCCESS.
+  \param None
+  \return player_t* player - Pointer to an allocated player variable.
 **/
 player_t* initDefaultPlayer();
 
 /**
   Initializes a sprite variable based on default parameters and ties the sprite
-  to the passed character reference.
+  to the passed character reference. Assumes sprite initialization can only
+  once for a character.
   \param character_t* character - Pointer to a character variable that the
                                   the sprite should be tied to.
-  \param sprite_t* sprite - Pointer to an allocated sprite variable.
-  \return SUCCESS.
+  \return SUCCESS if a sprite is initialized for character, or FAILURE if
+          sprite initialization fails.
 **/
 uint32_t initDefaultSprite(character_t* character);
 

--- a/labs/SAW/Game/src/Game.h
+++ b/labs/SAW/Game/src/Game.h
@@ -20,6 +20,14 @@
 // Structs
 ///////////////////////////////////////
 
+// Contains information related to character sprites
+typedef struct {
+  uint8_t frames[GAITS][DIRECTIONS][ANIMATION_STEPS];
+  uint32_t xPos;  // x position relative to the screen
+  uint32_t yPos;  // y position relative to the screen
+} sprite_t;
+
+
 // Contains information about in-game characters
 typedef struct {
   uint8_t name[MAX_NAME_LENGTH];
@@ -32,13 +40,6 @@ typedef struct {
 } character_t;
 
 typedef character_t player_t;
-
-// Contains information related to character sprites
-typedef struct {
-  uint8_t frames[GAITS][DIRECTIONS][ANIMATION_STEPS];
-  uint32_t xPos;  // x position relative to the screen
-  uint32_t yPos;  // y position relative to the screen
-} sprite_t;
 
 
 ///////////////////////////////////////

--- a/labs/SAW/SAW.md
+++ b/labs/SAW/SAW.md
@@ -1269,8 +1269,8 @@ field, the function sets that value to `NULL`. The `Game` library assumes that
 a character's sprite (and by extension, player sprites too) can only be set 
 once. Given that the only information known to the game is to initialize a 
 default player, it does not yet know what sprite information it should use. 
-Instead, the game relies on a separate function call to initialize the `sprite` 
-field.
+The game will rely on a separate function call to initialize the `sprite` field
+when more information is known later.
 
 We can craft a contract to verify this initialization function like so:
 
@@ -1295,14 +1295,16 @@ class initDefaultPlayer_Contract(Contract):
     self.returns(player)
 ```
 
-Notice that our contract immediately goes into the execute state. There isn't a
-need to define any variables in the initial state since there aren't any inputs
-being passed to `initDefaultPlayer`. Although the function does allocate
-memory for `player`, that is done as a function operation and passed as a return
-value. As such, we represent that allocation in the function's final state.
+Notice that our contract immediately goes into the *execute state*. There isn't a
+need to define any variables in the *initial state* since there aren't any inputs
+passed to `initDefaultPlayer`. Although the function does allocate memory for 
+`player`, that is done as a function operation and passed as a return value. As
+such, we represent that allocation in the function's *final state*.
 
 For every C symbol defined using `#define` in the source code, we make a 
-corresponding Python global variable.
+corresponding Python global variable. At this point, we only care about
+`MAX_NAME_LENGTH` since that is the only constant `initDefaultPlayer`
+references so far.
 
 ```python
 MAX_NAME_LENGTH = 12
@@ -1556,7 +1558,7 @@ The First `struct` Instance:
 For `character_p`, we assert the precondition that our pointer points to this 
 symbolic struct containing our fresh variables `name`, `level`, `hp`, `atk`, 
 `defense`, `spd`, and `null()`. Notice that we don't need to allocate memory
-yet in the contract's initial state for a `sprite_t` struct since the function
+yet in the contract's *initial state* for a `sprite_t` struct since the function
 assumes the passed `character` does not have an allocated sprite. As a result,
 we match the function's assumption that the `sprite` field is `NULL`.
 
@@ -1588,7 +1590,7 @@ The Third `struct` Instance:
 Now that `sprite_p` has been allocated and its field values were asserted, we
 connect `sprite_p` to `character_p`. The other fields for `character` do not
 change in the function, so we can resuse the symbolic variables that were 
-defined in the contract's initial state.
+defined in the contract's *initial state*.
 
 As we can see, the `struct` keyword is quite versatile as we can pass symbolic
 variables, symbolic pointers, and even define specific Cryptol values to it.

--- a/labs/SAW/SAW.md
+++ b/labs/SAW/SAW.md
@@ -1495,6 +1495,12 @@ struct and initializing the `sprite` fields for `character`.
 Now, let's go ahead and make a contract to represent this function:
 
 ```python
+SUCCESS         = 170
+FAILURE         = 85
+GAITS           = 2
+DIRECTIONS      = 4
+ANIMATION_STEPS = 3
+
 class initDefaultSprite_Contract(Contract):
   def specification (self):
     name        = self.fresh_var(array_ty(MAX_NAME_LENGTH, i8), "character.name")


### PR DESCRIPTION
Branch made in response to resolve issues found in #216 

# Features
- Adjusted the Game lab's `sprite_t` and `character_t` structs to establish a better connection.
- Adjusted the Game lab's `initDefaultPlayer` and `initDefaultSprite` functions to better illustrate intended lessons for SAW struct representation.
- Updated the contracts in `Game_answers.py` to reflect the `sprite_t` and `character_t` changes.
- Updated `SAW.md` to reflect the `sprite_t` and `character_t` changes both in terms of examples and documentation.
- Restructured some of the Struct chapters in `SAW.md`.
- Updated `Game/DLC/` to account for the changes made in the base Game lab.