### PR TITLE
GitHub Actions Update

### DIFF
--- a/.github/workflows/cryptol-ci.yml
+++ b/.github/workflows/cryptol-ci.yml
@@ -5,16 +5,23 @@ on: [push, pull_request]
 jobs:
   ci-load:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/weaversa/cryptol-course:2.13
-      options: --user root
+    services:
+      cryptol-remote-api:
+        image: ghcr.io/galoisinc/cryptol-remote-api:2.13.0
+	ports:
+	  - 8080:8080
+	options: -v ${{ github.workspace }}:/home/cryptol
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      # Start cryptol-remote-api server
-      - run: start-cryptol-remote-api-read-only
       # Load all files
+      - uses: actions/setup-python@v4
+        with:
+	  python-version: '3.10'
+      - run: pip install cryptol
       - run: python3 .ci/ci_load.py
+        env:
+	  CRYPTOL_SERVER_URL: http://0.0.0.0:8080
 
   ci-check:
     needs: ci-load

--- a/.github/workflows/cryptol-ci.yml
+++ b/.github/workflows/cryptol-ci.yml
@@ -8,20 +8,20 @@ jobs:
     services:
       cryptol-remote-api:
         image: ghcr.io/galoisinc/cryptol-remote-api:2.13.0
-	ports:
-	  - 8080:8080
-	options: -v ${{ github.workspace }}:/home/cryptol
+        ports:
+          - 8080:8080
+        options: -v ${{ github.workspace }}:/home/cryptol
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       # Load all files
       - uses: actions/setup-python@v4
         with:
-	  python-version: '3.10'
+          python-version: '3.10'
       - run: pip install cryptol
       - run: python3 .ci/ci_load.py
         env:
-	  CRYPTOL_SERVER_URL: http://0.0.0.0:8080
+          CRYPTOL_SERVER_URL: http://0.0.0.0:8080
 
   ci-check:
     needs: ci-load

--- a/.github/workflows/cryptol-ci.yml
+++ b/.github/workflows/cryptol-ci.yml
@@ -14,43 +14,60 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      # Load all files
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+      # Install Cryptol Client  
       - run: pip install cryptol
-      - run: python3 .ci/ci_load.py
+      # Load all files
+      - run: python .ci/ci_load.py
         env:
           CRYPTOL_SERVER_URL: http://0.0.0.0:8080
 
   ci-check:
     needs: ci-load
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/weaversa/cryptol-course:2.13
-      options: --user root
+    services:
+      cryptol-remote-api:
+        image: ghcr.io/galoisinc/cryptol-remote-api:2.13.0
+        ports:
+          - 8080:8080
+        options: -v ${{ github.workspace }}:/home/cryptol
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      # Install Cryptol Client  
+      - run: pip install cryptol
       - name: set pythonpath
         run: echo "PYTHONPATH=${PYTHONPATH}:${PWD}/.ci" >> $GITHUB_ENV
-      # Start cryptol-remote-api server
-      - run: start-cryptol-remote-api-read-only
       # Run checks
-      - run: for f in `find . -name "ci.py"`; do python3 $f; done
+      - run: for f in `find . -name "ci.py"`; do python $f; done
+        env:
+          CRYPTOL_SERVER_URL: http://0.0.0.0:8080
 
   ci-prove:
     needs: ci-load
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/weaversa/cryptol-course:2.13
-      options: --user root
+    services:
+      cryptol-remote-api:
+        image: ghcr.io/galoisinc/cryptol-remote-api:2.13.0
+        ports:
+          - 8080:8080
+        options: -v ${{ github.workspace }}:/home/cryptol
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      # Install Cryptol Client  
+      - run: pip install cryptol
       - name: set pythonpath
         run: echo "PYTHONPATH=${PYTHONPATH}:${PWD}/.ci" >> $GITHUB_ENV
-      # Start cryptol-remote-api server
-      - run: start-cryptol-remote-api-read-only
       # Run checks
-      - run: for f in `find . -name "ci_prove.py"`; do python3 $f; done
+      - run: for f in `find . -name "ci_prove.py"`; do python $f; done
+        env:
+          CRYPTOL_SERVER_URL: http://0.0.0.0:8080

--- a/.github/workflows/python-saw.yml
+++ b/.github/workflows/python-saw.yml
@@ -28,12 +28,9 @@ jobs:
   saw-prove:
     needs: build
     runs-on: ubuntu-latest
-    services:
-      saw-remote-api:
-        image: ghcr.io/galoisinc/saw-remote-api:nightly
-        ports:
-          - 8080:8080
-        options: -v ${{ github.workspaces }}:/home/saw
+    container:
+      image: ghcr.io/weaversa/cryptol-course:2.13
+      options: --user root
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -42,17 +39,13 @@ jobs:
         with:
           name: bc-files
           path: labs/Demos/SAW/
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-      - run: pip install saw-client
+      - name: Start saw-remote-api server
+        run: start-saw-remote-api-read-only
       - name: Run Python SAW Script
         run: |
-          python labs/Demos/SAW/xxHash/xxhash32-ref.py
-          python labs/Demos/SAW/xxHash/xxhash64-ref.py
-          python labs/Demos/SAW/Salsa20/proof/salsa20.py
-        env:
-          SAW_SERVER_URL: http://0.0.0.0:8080
+          python3 labs/Demos/SAW/xxHash/xxhash32-ref.py
+          python3 labs/Demos/SAW/xxHash/xxhash64-ref.py
+          python3 labs/Demos/SAW/Salsa20/proof/salsa20.py
 
   saw-tutorial:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-saw.yml
+++ b/.github/workflows/python-saw.yml
@@ -28,9 +28,12 @@ jobs:
   saw-prove:
     needs: build
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/weaversa/cryptol-course:2.13
-      options: --user root
+    services:
+      saw-remote-api:
+        image: ghcr.io/galoisinc/saw-remote-api:nightly
+        ports:
+          - 8080:8080
+        options: -v ${{ github.workspaces }}:/home/saw
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -39,13 +42,17 @@ jobs:
         with:
           name: bc-files
           path: labs/Demos/SAW/
-      - name: Start saw-remote-api server
-        run: start-saw-remote-api-read-only
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - run: pip install saw-client
       - name: Run Python SAW Script
         run: |
-          python3 labs/Demos/SAW/xxHash/xxhash32-ref.py
-          python3 labs/Demos/SAW/xxHash/xxhash64-ref.py
-          python3 labs/Demos/SAW/Salsa20/proof/salsa20.py
+          python labs/Demos/SAW/xxHash/xxhash32-ref.py
+          python labs/Demos/SAW/xxHash/xxhash64-ref.py
+          python labs/Demos/SAW/Salsa20/proof/salsa20.py
+        env:
+          SAW_SERVER_URL: http://0.0.0.0:8080
 
   saw-tutorial:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I changed `cryptol-remote-api` to run as a service in the CI so we don't have to use the huge dev image.

I left `saw-remote-api` as is for now since the `saw-client` python package in pip is old. Building the correct package and putting it in the right place doesn't seem like the best idea, but we could build a smaller container than the dev image if we wanted to have the saw jobs look similar to the cryptol ones. 