### PR TITLE
Mbeynon/fix pinneddep add userid gid

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -126,8 +126,7 @@ COPY .env /tmp/.env
 RUN . /tmp/.env && rm /tmp/.env \
     && groupadd -g ${USER_GID} -o ${USER_GNAME} \
     && useradd -m -u ${USER_UID} -g ${USER_GID} -o -s /bin/bash ${USER_NAME} \
-    && echo "${USER_NAME} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd \
-    && chown -R ${USER_NAME}:${USER_GNAME} /home/${USER_NAME}
+    && echo "${USER_NAME} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd
 USER ${USER_NAME}
 
 ENV LANG=C.UTF-8

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -120,14 +120,21 @@ RUN unzip -o ubuntu-latest-bin.zip -d /usr/local/bin && rm -rf ubuntu-latest-bin
 
 RUN chmod a+x /usr/local/bin/*
 
-RUN adduser --gecos '' --disabled-password cryptol \
-    && echo "cryptol ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd \
-    && chown -R cryptol:cryptol /home/cryptol
-USER cryptol
+# create local non-root user, but mimic host ids to avoid file permission problems
+ARG USER_NAME="cryptol"
+ARG USER_GNAME="cryptol"
+# Copy the .env file with USER_UID and USER_GID set in devcontainer.json
+COPY .env /tmp/.env
+RUN . /tmp/.env && rm /tmp/.env \
+    && groupadd -g ${USER_GID} -o ${USER_GNAME} \
+    && useradd -m -u ${USER_UID} -g ${USER_GID} -o -s /bin/bash ${USER_NAME} \
+    && echo "${USER_NAME} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd \
+    && chown -R ${USER_NAME}:${USER_GNAME} /home/${USER_NAME}
+USER ${USER_NAME}
 
 ENV LANG=C.UTF-8
-RUN sudo chsh -s /bin/bash $(whoami)
+RUN sudo chsh -s /bin/bash ${USER_NAME}
 ENV SHELL=/bin/bash
-RUN echo 'export PS1="[\u \W]\$ "' >> /home/cryptol/.bashrc
+RUN echo 'export PS1="[\u \W]\$ "' >> /home/${USER_NAME}/.bashrc
 
 # ENTRYPOINT ["/bin/bash"]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -109,7 +109,7 @@ RUN wget https://github.com/GaloisInc/saw-script/archive/refs/heads/master.zip &
 RUN mv saw-script-master /usr/local/share/saw-script && rm -rf master.zip
 
 # Link to nightly python clients
-ENV PYTHONPATH "${PYTHONPATH}:/usr/local/share/cryptol/cryptol-remote-api/python:/usr/local/share/saw-script/saw-remote-api/python"
+ENV PYTHONPATH="${PYTHONPATH}:/usr/local/share/cryptol/cryptol-remote-api/python:/usr/local/share/saw-script/saw-remote-api/python"
 
 # Install Python client dependencies
 RUN pip3 install typing_extensions argo_client BitVector
@@ -125,7 +125,7 @@ RUN adduser --gecos '' --disabled-password cryptol \
     && chown -R cryptol:cryptol /home/cryptol
 USER cryptol
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 RUN sudo chsh -s /bin/bash $(whoami)
 ENV SHELL=/bin/bash
 RUN echo 'export PS1="[\u \W]\$ "' >> /home/cryptol/.bashrc

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -122,8 +122,8 @@ RUN chmod a+x /usr/local/bin/*
 ARG USER_NAME="cryptol"
 ARG USER_GNAME="cryptol"
 # Copy the .env file with USER_UID and USER_GID set in devcontainer.json
-COPY .env /tmp/.env
-RUN . /tmp/.env && rm /tmp/.env \
+COPY vars.env /tmp/vars.env
+RUN . /tmp/vars.env && rm /tmp/vars.env \
     && groupadd -g ${USER_GID} -o ${USER_GNAME} \
     && useradd -m -u ${USER_UID} -g ${USER_GID} -o -s /bin/bash ${USER_NAME} \
     && echo "${USER_NAME} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update \
     && DEBIAN_FRONTEND="noninteractive" apt-get install --yes \
       bash \
       build-essential \
-      containerd.io=1.5.11-1 \
+      containerd.io \
       docker-ce \
       docker-ce-cli \
       docker-compose-plugin \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,8 +20,6 @@ RUN echo \
     $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
 
 # Install all tools
-# We use an old containerd.io because it contains a version of runc that works
-# with sysbox correctly.
 RUN apt-get update \
     && DEBIAN_FRONTEND="noninteractive" apt-get install --yes \
       bash \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -130,7 +130,6 @@ RUN . /tmp/.env && rm /tmp/.env \
 USER ${USER_NAME}
 
 ENV LANG=C.UTF-8
-RUN sudo chsh -s /bin/bash ${USER_NAME}
 ENV SHELL=/bin/bash
 RUN echo 'export PS1="[\u \W]\$ "' >> /home/${USER_NAME}/.bashrc
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,16 +4,9 @@
     "dockerFile": "Dockerfile",
     "runArgs": [],
 
-    // pass through the UID and GID from the host, so can edit files in the container
-    // Note: cannot do with build.args because ${localEnv:USER_UID} doesn't work,
-    // and shell command substitution is not implemented in devcontainer.json.
-    // "build": {
-    //     "args": {
-    //         "USER_UID": "${localEnv:USER_UID}",
-    //         "USER_GID": "${localEnv:USER_GID}"
-    //     },
-    // },
-    "initializeCommand": "echo \"USER_UID=$(id -u)\nUSER_GID=$(id -g)\" > .devcontainer/.env",
+    // Pass through the UID and GID from the host, so can edit files in the container.
+    // If root:root is found, instead use 1000:1000 for the container user.
+    "initializeCommand": ".devcontainer/get_uid_gid.sh > .devcontainer/.env",
 
     // Use 'settings' to set *default* container specific settings.json values on container create. 
     // You can edit these settings after create using File > Preferences > Settings > Remote.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,17 @@
     "dockerFile": "Dockerfile",
     "runArgs": [],
 
+    // pass through the UID and GID from the host, so can edit files in the container
+    // Note: cannot do with build.args because ${localEnv:USER_UID} doesn't work,
+    // and shell command substitution is not implemented in devcontainer.json.
+    // "build": {
+    //     "args": {
+    //         "USER_UID": "${localEnv:USER_UID}",
+    //         "USER_GID": "${localEnv:USER_GID}"
+    //     },
+    // },
+    "initializeCommand": "echo \"USER_UID=$(id -u)\nUSER_GID=$(id -g)\" > .devcontainer/.env",
+
     // Use 'settings' to set *default* container specific settings.json values on container create. 
     // You can edit these settings after create using File > Preferences > Settings > Remote.
     "settings": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
 
     // Pass through the UID and GID from the host, so can edit files in the container.
     // If root:root is found, instead use 1000:1000 for the container user.
-    "initializeCommand": ".devcontainer/get_uid_gid.sh > .devcontainer/.env",
+    "initializeCommand": ".devcontainer/get_uid_gid.sh > .devcontainer/vars.env",
 
     // Use 'settings' to set *default* container specific settings.json values on container create. 
     // You can edit these settings after create using File > Preferences > Settings > Remote.

--- a/.devcontainer/get_uid_gid.sh
+++ b/.devcontainer/get_uid_gid.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# determine the caller's uid:gid to use in container
+USER_UID=$(id -u)
+USER_GID=$(id -g)
+
+# check if running as root, and instead use 1000:1000
+if [ "${USER_UID}" = "0" ]
+then
+    USER_UID=1000
+fi
+if [ "${USER_GID}" = "0" ]
+then
+    USER_GID=1000
+fi
+
+echo "# created by .devcontainer/get_uid_gid.sh"
+echo "USER_UID=${USER_UID}"
+echo "USER_GID=${USER_GID}"
+
+exit 0

--- a/.devcontainer/vars.env
+++ b/.devcontainer/vars.env
@@ -1,0 +1,3 @@
+# default (replaced if using Dev Container)
+USER_UID=1000
+USER_GID=1000

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 **/.DS_Store
 **/*.bc
 **/*~
-.devcontainer/.env
+.devcontainer/vars.env

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/.DS_Store
 **/*.bc
 **/*~
+.devcontainer/.env


### PR DESCRIPTION
I made a few changes when trying to use this on a macOS laptop with vscode and Dev Containers using docker setup with `amd64` arch.

1. The dev container build would fail because the pinned containerd.io=1.5.11-1 appears inconsistent with other packages that are not pinned.  Removing the version pin allows it to build, but I don't know if that affects the reason why this was pinned in the first place: [link to comment](https://github.com/weaversa/cryptol-course/blob/ec364f11234deade969336fec5a6919ebf6b8868/.devcontainer/Dockerfile#L23)

2. Once the dev container was built, I was unable to write files into the mapped folder because the created user `cryptol` with uid=1000, gid=1000, does not make sense on my host laptop.  I modified devcontainer.json to create a temp .env file that's used by the Dockerfile to mimic the same uid and gid that the host user running vscode has, so file permissions work as expected.

As a result of these changes, the devcontainer starts and executes as expected.

I only tested this on my macOS laptop.